### PR TITLE
Updated docs for release: 11.04.2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Azure AppCAT
+# Azure Migrate application and code assessment for Java
 
-The Azure Application and Code Assessment Toolkit (AppCAT) is a set of tools to help customers assess their applications prior to deployment to Azure. 
+The Azure Migrate application and code assessment for Java (AppCAT for Java) is a set of tools to help customers assess their applications prior to deployment to Azure. 
 
 This repository holds the HTML-generated documentation of said tools. The documentation is primarily based on the upstream repository [windup-documentation](https://github.com/windup/windup-documentation).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Migrate application and code assessment for Java
 
-The Azure Migrate application and code assessment for Java (AppCAT for Java) is a set of tools to help customers assess their applications prior to deployment to Azure. 
+The Azure Migrate application and code assessment for Java is a set of tools to help customers assess their applications prior to deployment to Azure. 
 
 This repository holds the HTML-generated documentation of said tools. The documentation is primarily based on the upstream repository [windup-documentation](https://github.com/windup/windup-documentation).
 

--- a/docs/cli/index.html
+++ b/docs/cli/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
-<meta name="author" content="CLI Guide (Version: 6.3.0)">
-<title>Azure Application and Code Assessment Toolkit</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
-<style>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="Asciidoctor 2.0.10">
+    <meta name="author" content="CLI Guide (Version: 6.3.0)">
+    <title>Azure Migrate application and code assessment for Java</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+    <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
@@ -439,379 +439,379 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body id="cli-guide" class="book">
 <div id="header">
-<h1>Azure Application and Code Assessment Toolkit</h1>
-<div class="details">
-<span id="author" class="author">CLI Guide (Version: 6.3.0)</span><br>
-</div>
-<div id="toc" class="toc">
-<div id="toctitle">Table of Contents</div>
-<ul class="sectlevel1">
-<li><a href="#_introduction">1. Introduction</a>
-<ul class="sectlevel2">
-<li><a href="#about-cli-guide_cli-guide">1.1. About the CLI Guide</a></li>
-<li><a href="#what-is-the-toolkit_cli-guide">1.2. About the Azure Application and Code Assessment Toolkit</a></li>
-</ul>
-</li>
-<li><a href="#_installing_and_running_the_cli">2. Installing and Running the CLI</a>
-<ul class="sectlevel2">
-<li><a href="#installing-web-console-or-cli-tool_cli-guide">2.1. Installing the CLI</a></li>
-<li><a href="#cli-run_cli-guide">2.2. Running the CLI</a>
-<ul class="sectlevel3">
-<li><a href="#command-examples_cli-guide">2.2.1. APPCAT command examples</a></li>
-<li><a href="#cli-bash-completion_cli-guide">2.2.2. APPCAT CLI Bash completion</a></li>
-<li><a href="#accessing-help_cli-guide">2.2.3. Accessing APPCAT help</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#access-report_cli-guide">3. Accessing reports</a>
-<ul class="sectlevel2">
-<li><a href="#review-reports_cli-guide">3.1. Reviewing the reports</a>
-<ul class="sectlevel3">
-<li><a href="#review-application-report_cli-guide">3.1.1. Application report</a></li>
-<li><a href="#technology-report_cli-guide">3.1.2. Technologies report across multiple applications</a></li>
-<li><a href="#shared-archives_cli-guide">3.1.3. Archives shared by multiple applications</a></li>
-<li><a href="#review-rule-providers-execution-overview_cli-guide">3.1.4. Rule providers execution overview</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#csv-export_cli-guide">4. Exporting the report in CSV format</a>
-<ul class="sectlevel2">
-<li><a href="#export-the-report_cli-guide">4.1. Exporting the report</a></li>
-<li><a href="#_importing_the_csv_file_into_a_spreadsheet_program">4.2. Importing the CSV file into a spreadsheet program</a></li>
-<li><a href="#_about_the_csv_data_structure">4.3. About the CSV data structure</a></li>
-</ul>
-</li>
-<li><a href="#optimize-performance_cli-guide">5. Optimizing APPCAT performance</a>
-<ul class="sectlevel2">
-<li><a href="#_deploying_and_running_the_application">5.1. Deploying and running the application</a></li>
-<li><a href="#_upgrading_hardware">5.2. Upgrading hardware</a></li>
-<li><a href="#exclude-files-and-packages_cli-guide">5.3. Configuring APPCAT to exclude packages and files</a>
-<ul class="sectlevel3">
-<li><a href="#exclude-packages_cli-guide">5.3.1. Excluding packages</a></li>
-<li><a href="#exclude-files_cli-guide">5.3.2. Excluding files</a></li>
-<li><a href="#ignored-locations_cli-guide">5.3.3. Searching locations for exclusion</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#_reference_material">Appendix A: Reference material</a>
-<ul class="sectlevel2">
-<li><a href="#cli-args_cli-guide">A.1. About APPCAT command-line arguments</a>
-<ul class="sectlevel3">
-<li><a href="#cli-input-argument_cli-guide">A.1.1. Specifying the input</a></li>
-<li><a href="#cli-output-argument_cli-guide">A.1.2. Specifying the output directory</a></li>
-<li><a href="#cli-source-argument_cli-guide">A.1.3. Setting the source technology</a></li>
-<li><a href="#cli-target-argument_cli-guide">A.1.4. Setting the target technology</a></li>
-<li><a href="#cli-packages-argument_cli-guide">A.1.5. Selecting packages</a></li>
-</ul>
-</li>
-<li><a href="#tech-tags_cli-guide">A.2. Supported technology tags</a></li>
-<li><a href="#about-story-points_cli-guide">A.3. About rule story points</a>
-<ul class="sectlevel3">
-<li><a href="#_what_are_story_points">A.3.1. What are story points?</a></li>
-<li><a href="#_how_story_points_are_estimated_in_rules">A.3.2. How story points are estimated in rules</a></li>
-<li><a href="#_task_category">A.3.3. Task category</a></li>
-</ul>
-</li>
-<li><a href="#_additional_resources">A.4. Additional Resources</a>
-<ul class="sectlevel3">
-<li><a href="#get-involved_cli-guide">A.4.1. Getting involved</a></li>
-<li><a href="#important-links_cli-guide">A.4.2. Resources</a></li>
-<li><a href="#_reporting_issues">A.4.3. Reporting issues</a></li>
-</ul>
-</li>
-</ul>
-</li>
-</ul>
-</div>
+    <h1>Azure Migrate application and code assessment for Java</h1>
+    <div class="details">
+        <span id="author" class="author">CLI Guide (Version: 6.3.0)</span><br>
+    </div>
+    <div id="toc" class="toc">
+        <div id="toctitle">Table of Contents</div>
+        <ul class="sectlevel1">
+            <li><a href="#_introduction">1. Introduction</a>
+                <ul class="sectlevel2">
+                    <li><a href="#about-cli-guide_cli-guide">1.1. About the CLI Guide</a></li>
+                    <li><a href="#what-is-the-toolkit_cli-guide">1.2. About the Azure Migrate application and code assessment for Java</a></li>
+                </ul>
+            </li>
+            <li><a href="#_installing_and_running_the_cli">2. Installing and Running the CLI</a>
+                <ul class="sectlevel2">
+                    <li><a href="#installing-web-console-or-cli-tool_cli-guide">2.1. Installing the CLI</a></li>
+                    <li><a href="#cli-run_cli-guide">2.2. Running the CLI</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#command-examples_cli-guide">2.2.1. APPCAT command examples</a></li>
+                            <li><a href="#cli-bash-completion_cli-guide">2.2.2. APPCAT CLI Bash completion</a></li>
+                            <li><a href="#accessing-help_cli-guide">2.2.3. Accessing APPCAT help</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li><a href="#access-report_cli-guide">3. Accessing reports</a>
+                <ul class="sectlevel2">
+                    <li><a href="#review-reports_cli-guide">3.1. Reviewing the reports</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#review-application-report_cli-guide">3.1.1. Application report</a></li>
+                            <li><a href="#technology-report_cli-guide">3.1.2. Technologies report across multiple applications</a></li>
+                            <li><a href="#shared-archives_cli-guide">3.1.3. Archives shared by multiple applications</a></li>
+                            <li><a href="#review-rule-providers-execution-overview_cli-guide">3.1.4. Rule providers execution overview</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li><a href="#csv-export_cli-guide">4. Exporting the report in CSV format</a>
+                <ul class="sectlevel2">
+                    <li><a href="#export-the-report_cli-guide">4.1. Exporting the report</a></li>
+                    <li><a href="#_importing_the_csv_file_into_a_spreadsheet_program">4.2. Importing the CSV file into a spreadsheet program</a></li>
+                    <li><a href="#_about_the_csv_data_structure">4.3. About the CSV data structure</a></li>
+                </ul>
+            </li>
+            <li><a href="#optimize-performance_cli-guide">5. Optimizing APPCAT performance</a>
+                <ul class="sectlevel2">
+                    <li><a href="#_deploying_and_running_the_application">5.1. Deploying and running the application</a></li>
+                    <li><a href="#_upgrading_hardware">5.2. Upgrading hardware</a></li>
+                    <li><a href="#exclude-files-and-packages_cli-guide">5.3. Configuring APPCAT to exclude packages and files</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#exclude-packages_cli-guide">5.3.1. Excluding packages</a></li>
+                            <li><a href="#exclude-files_cli-guide">5.3.2. Excluding files</a></li>
+                            <li><a href="#ignored-locations_cli-guide">5.3.3. Searching locations for exclusion</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li><a href="#_reference_material">Appendix A: Reference material</a>
+                <ul class="sectlevel2">
+                    <li><a href="#cli-args_cli-guide">A.1. About APPCAT command-line arguments</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#cli-input-argument_cli-guide">A.1.1. Specifying the input</a></li>
+                            <li><a href="#cli-output-argument_cli-guide">A.1.2. Specifying the output directory</a></li>
+                            <li><a href="#cli-source-argument_cli-guide">A.1.3. Setting the source technology</a></li>
+                            <li><a href="#cli-target-argument_cli-guide">A.1.4. Setting the target technology</a></li>
+                            <li><a href="#cli-packages-argument_cli-guide">A.1.5. Selecting packages</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#tech-tags_cli-guide">A.2. Supported technology tags</a></li>
+                    <li><a href="#about-story-points_cli-guide">A.3. About rule story points</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#_what_are_story_points">A.3.1. What are story points?</a></li>
+                            <li><a href="#_how_story_points_are_estimated_in_rules">A.3.2. How story points are estimated in rules</a></li>
+                            <li><a href="#_task_category">A.3.3. Task category</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#_additional_resources">A.4. Additional Resources</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#get-involved_cli-guide">A.4.1. Getting involved</a></li>
+                            <li><a href="#important-links_cli-guide">A.4.2. Resources</a></li>
+                            <li><a href="#_reporting_issues">A.4.3. Reporting issues</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
 </div>
 <div id="content">
-<div class="sect1">
-<h2 id="_introduction">1. Introduction</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="about-cli-guide_cli-guide">1.1. About the CLI Guide</h3>
-<div class="paragraph">
-<p>This guide is for engineers, consultants, and others who want to use the Azure Application and Code Assessment Toolkit (APPCAT) to migrate Java applications or other components. It describes how to install and run the CLI, review the generated reports, and take advantage of additional features.</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="what-is-the-toolkit_cli-guide">1.2. About the Azure Application and Code Assessment Toolkit</h3>
-<h4 id="_what_is_the_azure_application_and_code_assessment_toolkit" class="discrete">What is the Azure Application and Code Assessment Toolkit?</h4>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit (APPCAT) is an extensible and customizable rule-based tool that simplifies the migration and modernization of Java applications.</p>
-</div>
-<div class="paragraph">
-<p>APPCAT examines application artifacts, including project source directories and application archives, and then produces an HTML report highlighting areas needing changes. APPCAT supports many migration paths, including the following examples:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>Replatforming connectivity between applications and external resources to leverage Azure services</p>
-</li>
-<li>
-<p>Assessing code patterns for Cloud hosted resources such as databases, messaging queues, logging systems, and more</p>
-</li>
-<li>
-<p>Containerizing applications and making them cloud-ready</p>
-</li>
-<li>
-<p>Assessing code patterns for better security</p>
-</li>
-<li>
-<p>Upgrading OpenJDK versions and distributions</p>
-</li>
-<li>
-<p>Upgrading commonly used libraries and frameworks</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>For more information about use cases and migration paths, see the <a href="https://learn.microsoft.com/azure/developer/java/migration/">Java to Azure migration strategy documentation</a>.</p>
-</div>
-<h4 id="_how_does_the_azure_application_and_code_assessment_toolkit_simplify_migration" class="discrete">How does the Azure Application and Code Assessment Toolkit simplify migration?</h4>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit looks for common resources and known trouble spots when migrating applications. It provides a high-level view of the technologies used by the application.</p>
-</div>
-<div class="paragraph">
-<p>APPCAT generates a detailed report evaluating a migration or modernization path. This report can help you to estimate the effort required for large-scale projects and to reduce the work involved.</p>
-</div>
-<h3 id="about-cli_cli-guide" class="discrete">About the CLI</h3>
-<div class="paragraph">
-<p>The CLI is a command-line tool in the Azure Application and Code Assessment Toolkit that allows you to assess and prioritize migration and modernization efforts for applications. It provides numerous reports that highlight the analysis without the overhead of the other tools. The CLI includes a wide array of customization options, and allows you to finely tune APPCAT analysis options or integrate with external automation tools.</p>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_installing_and_running_the_cli">2. Installing and Running the CLI</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="installing-web-console-or-cli-tool_cli-guide">2.1. Installing the CLI</h3>
-<div class="paragraph">
-<p>You can install the CLI on Linux, Windows, or macOS operating systems.</p>
-</div>
-<div class="ulist">
-<div class="title">Prerequisites</div>
-<ul>
-<li>
-<p>Java Development Kit (JDK) installed. APPCAT supports the following JDKs:</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Microsoft Build of OpenJDK 11</p>
-</li>
-<li>
-<p>Microsoft Build of OpenJDK 17</p>
-</li>
-<li>
-<p>Eclipse Temurin™ JDK 11</p>
-</li>
-<li>
-<p>Eclipse Temurin™ JDK 17</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>8 GB RAM</p>
-</li>
-<li>
-<p>macOS installation: the value of <code>maxproc</code> must be <code>2048</code> or greater.</p>
-</li>
-</ul>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Extract the <code>.zip</code> file to a directory of your choice.</p>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>If you are installing on a Windows operating system:</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Extract the <code>.zip</code> file to a folder named <code>appcat</code> to avoid a <code>Path too long</code> error. Alternatively, extract the file with <a href="https://www.7-zip.org/download.html">7-Zip</a> to a folder of any name you choose.</p>
-</li>
-<li>
-<p>If a <strong>Confirm file replace</strong> window is displayed during extraction, click <strong>Yes to all</strong>.</p>
-</li>
-</ol>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>When you encounter <code>&lt;APPCAT_HOME&gt;</code> in this guide, replace it with the actual path to your APPCAT installation.</p>
-</div>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="cli-run_cli-guide">2.2. Running the CLI</h3>
-<div class="paragraph">
-<p>You can run APPCAT against your application or project source code folder.</p>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Open a terminal and navigate to the <code>&lt;APPCAT_HOME&gt;/bin/</code> directory.</p>
-</li>
-<li>
-<p>Execute the <code>appcat-cli</code> script, or <code>appcat-cli.bat</code> for Windows, and specify the appropriate arguments:</p>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ ./appcat-cli --input /path/to/example-app-1.0.0.war \
+    <div class="sect1">
+        <h2 id="_introduction">1. Introduction</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="about-cli-guide_cli-guide">1.1. About the CLI Guide</h3>
+                <div class="paragraph">
+                    <p>This guide is for engineers, consultants, and others who want to use the Azure Migrate application and code assessment for Java (APPCAT) to migrate Java applications or other components. It describes how to install and run the CLI, review the generated reports, and take advantage of additional features.</p>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="what-is-the-toolkit_cli-guide">1.2. About the Azure Migrate application and code assessment for Java</h3>
+                <h4 id="_what_is_the_azure_migrate_application_and_code_assessment_for_java" class="discrete">What is the Azure Migrate application and code assessment for Java?</h4>
+                <div class="paragraph">
+                    <p>The Azure Migrate application and code assessment for Java (APPCAT) is an extensible and customizable rule-based tool that simplifies the migration and modernization of Java applications.</p>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT examines application artifacts, including project source directories and application archives, and then produces an HTML report highlighting areas needing changes. APPCAT supports many migration paths, including the following examples:</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>Replatforming connectivity between applications and external resources to leverage Azure services</p>
+                        </li>
+                        <li>
+                            <p>Assessing code patterns for Cloud hosted resources such as databases, messaging queues, logging systems, and more</p>
+                        </li>
+                        <li>
+                            <p>Containerizing applications and making them cloud-ready</p>
+                        </li>
+                        <li>
+                            <p>Assessing code patterns for better security</p>
+                        </li>
+                        <li>
+                            <p>Upgrading OpenJDK versions and distributions</p>
+                        </li>
+                        <li>
+                            <p>Upgrading commonly used libraries and frameworks</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="paragraph">
+                    <p>For more information about use cases and migration paths, see the <a href="https://learn.microsoft.com/azure/developer/java/migration/">Java to Azure migration strategy documentation</a>.</p>
+                </div>
+                <h4 id="_how_does_the_azure_migrate_application_and_code_assessment_for_java_simplify_migration" class="discrete">How does the Azure Migrate application and code assessment for Java simplify migration?</h4>
+                <div class="paragraph">
+                    <p>The Azure Migrate application and code assessment for Java looks for common resources and known trouble spots when migrating applications. It provides a high-level view of the technologies used by the application.</p>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT generates a detailed report evaluating a migration or modernization path. This report can help you to estimate the effort required for large-scale projects and to reduce the work involved.</p>
+                </div>
+                <h3 id="about-cli_cli-guide" class="discrete">About the CLI</h3>
+                <div class="paragraph">
+                    <p>The CLI is a command-line tool in the Azure Migrate application and code assessment for Java that allows you to assess and prioritize migration and modernization efforts for applications. It provides numerous reports that highlight the analysis without the overhead of the other tools. The CLI includes a wide array of customization options, and allows you to finely tune APPCAT analysis options or integrate with external automation tools.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="_installing_and_running_the_cli">2. Installing and Running the CLI</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="installing-web-console-or-cli-tool_cli-guide">2.1. Installing the CLI</h3>
+                <div class="paragraph">
+                    <p>You can install the CLI on Linux, Windows, or macOS operating systems.</p>
+                </div>
+                <div class="ulist">
+                    <div class="title">Prerequisites</div>
+                    <ul>
+                        <li>
+                            <p>Java Development Kit (JDK) installed. APPCAT supports the following JDKs:</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Microsoft Build of OpenJDK 11</p>
+                                    </li>
+                                    <li>
+                                        <p>Microsoft Build of OpenJDK 17</p>
+                                    </li>
+                                    <li>
+                                        <p>Eclipse Temurin™ JDK 11</p>
+                                    </li>
+                                    <li>
+                                        <p>Eclipse Temurin™ JDK 17</p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li>
+                            <p>8 GB RAM</p>
+                        </li>
+                        <li>
+                            <p>macOS installation: the value of <code>maxproc</code> must be <code>2048</code> or greater.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>Extract the <code>.zip</code> file to a directory of your choice.</p>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>If you are installing on a Windows operating system:</p>
+                                            </div>
+                                            <div class="olist arabic">
+                                                <ol class="arabic">
+                                                    <li>
+                                                        <p>Extract the <code>.zip</code> file to a folder named <code>appcat</code> to avoid a <code>Path too long</code> error. Alternatively, extract the file with <a href="https://www.7-zip.org/download.html">7-Zip</a> to a folder of any name you choose.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p>If a <strong>Confirm file replace</strong> window is displayed during extraction, click <strong>Yes to all</strong>.</p>
+                                                    </li>
+                                                </ol>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                            <div class="paragraph">
+                                <p>When you encounter <code>&lt;APPCAT_HOME&gt;</code> in this guide, replace it with the actual path to your APPCAT installation.</p>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="cli-run_cli-guide">2.2. Running the CLI</h3>
+                <div class="paragraph">
+                    <p>You can run APPCAT against your application or project source code folder.</p>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>Open a terminal and navigate to the <code>&lt;APPCAT_HOME&gt;/bin/</code> directory.</p>
+                        </li>
+                        <li>
+                            <p>Execute the <code>appcat</code> script, or <code>appcat.bat</code> for Windows, and specify the appropriate arguments:</p>
+                            <div class="listingblock">
+                                <div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ ./appcat --input /path/to/example-app-1.0.0.war \
     --output /path/to/output \
     --target azure-appservice \
     --packages com.acme org.apache</code></pre>
-</div>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>--input</code>: The application to be evaluated.</p>
-</li>
-<li>
-<p><code>--output</code>: The output directory for the generated reports.</p>
-</li>
-<li>
-<p><code>--target</code>: The target Azure service for the application migration.</p>
-</li>
-<li>
-<p><code>--packages</code>: The packages to be evaluated. This argument is highly recommended to improve performance and narrow scope.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Access the report by opening the <code>index.html</code> file in the output folder.</p>
-</li>
-</ol>
-</div>
-<div class="sect3">
-<h4 id="command-examples_cli-guide">2.2.1. APPCAT command examples</h4>
-<h5 id="_running_appcat_on_an_application_archive" class="discrete">Running APPCAT on an application archive</h5>
-<div class="paragraph">
-<p>The following command analyzes the <code>org.airsonic</code> package of the <a href="https://github.com/airsonic/airsonic/releases/download/v10.6.2/airsonic.war">airsonic.war</a> example WAR archive for migrating from Apache Tomcat to Azure App Service:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli \
+                                </div>
+                            </div>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p><code>--input</code>: The application to be evaluated.</p>
+                                    </li>
+                                    <li>
+                                        <p><code>--output</code>: The output directory for the generated reports.</p>
+                                    </li>
+                                    <li>
+                                        <p><code>--target</code>: The target Azure service for the application migration.</p>
+                                    </li>
+                                    <li>
+                                        <p><code>--packages</code>: The packages to be evaluated. This argument is highly recommended to improve performance and narrow scope.</p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Access the report by opening the <code>index.html</code> file in the output folder.</p>
+                        </li>
+                    </ol>
+                </div>
+                <div class="sect3">
+                    <h4 id="command-examples_cli-guide">2.2.1. APPCAT command examples</h4>
+                    <h5 id="_running_appcat_on_an_application_archive" class="discrete">Running APPCAT on an application archive</h5>
+                    <div class="paragraph">
+                        <p>The following command analyzes the <code>org.airsonic</code> package of the <a href="https://github.com/airsonic/airsonic/releases/download/v10.6.2/airsonic.war">airsonic.war</a> example WAR archive for migrating from Apache Tomcat to Azure App Service:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat \
     --input /path/to/airsonic.war \
     --output /path/to/report-output/ \
     --target azure-appservice \
     --packages org.airsonic</code></pre>
-</div>
-</div>
-<h5 id="_running_appcat_on_source_code" class="discrete">Running APPCAT on source code</h5>
-<div class="paragraph">
-<p>The following command analyzes the <code>org.airsonic</code> package of the <a href="https://github.com/airsonic/airsonic/archive/refs/tags/v10.6.2.zip">airsonic-v10.6.2.zip</a> example source code for migrating to Azure App Service.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli
+                        </div>
+                    </div>
+                    <h5 id="_running_appcat_on_source_code" class="discrete">Running APPCAT on source code</h5>
+                    <div class="paragraph">
+                        <p>The following command analyzes the <code>org.airsonic</code> package of the <a href="https://github.com/airsonic/airsonic/archive/refs/tags/v10.6.2.zip">airsonic-v10.6.2.zip</a> example source code for migrating to Azure App Service.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat
     --sourceMode \
     --input /path/to/airsonic-v10.6.2/airsonic-main \
     --output /path/to/report-output/ \
     --target azure-appservice \
     --packages org.airsonic</code></pre>
-</div>
-</div>
-<h5 id="_overriding_appcat_properties" class="discrete">Overriding APPCAT properties</h5>
-<div class="paragraph">
-<p>To override the default <em>Fernflower</em> decompiler, pass the <code>-Dwindup.decompiler</code> argument on the command line. For example, to use the <em>Procyon</em> decompiler, use the following syntax:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli -Dwindup.decompiler=procyon \
+                        </div>
+                    </div>
+                    <h5 id="_overriding_appcat_properties" class="discrete">Overriding APPCAT properties</h5>
+                    <div class="paragraph">
+                        <p>To override the default <em>Fernflower</em> decompiler, pass the <code>-Dwindup.decompiler</code> argument on the command line. For example, to use the <em>Procyon</em> decompiler, use the following syntax:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat -Dwindup.decompiler=procyon \
     --input &lt;INPUT_ARCHIVE_OR_DIRECTORY&gt; --output &lt;OUTPUT_REPORT_DIRECTORY&gt; \
     --target &lt;TARGET_TECHNOLOGY&gt; --packages &lt;PACKAGE_1&gt; &lt;PACKAGE_2&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="cli-bash-completion_cli-guide">2.2.2. APPCAT CLI Bash completion</h4>
-<div class="paragraph">
-<p>The APPCAT CLI provides an option to enable Bash completion for Linux systems, allowing the APPCAT command-line arguments to be auto completed by pressing the Tab key when entering the commands. For instance, when Bash completion is enabled, entering the following displays a list of available arguments.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli [TAB]</code></pre>
-</div>
-</div>
-<h5 id="bash-completion-temporary_cli-guide" class="discrete">Enabling Bash completion</h5>
-<div class="paragraph">
-<p>To enable Bash completion for the current shell, execute the following command:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ source &lt;APPCAT_HOME&gt;/bash-completion/appcat-cli</code></pre>
-</div>
-</div>
-<h5 id="bash-completion-persistent_cli-guide" class="discrete">Enabling persistent Bash completion</h5>
-<div class="paragraph">
-<p>The following commands allow Bash completion to persist across restarts:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>To enable Bash completion for a specific user across system restarts, include the following line in that user&#8217;s <code>~/.bashrc</code> file.</p>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">source &lt;APPCAT_HOME&gt;/bash-completion/appcat-cli</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>To enable Bash completion for all users across system restarts, copy the Azure Application and Code Assessment Toolkit CLI Bash completion file to the <code>/etc/bash_completion.d/</code> directory as the root user.</p>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal"># cp &lt;APPCAT_HOME&gt;/bash-completion/appcat-cli /etc/bash_completion.d/</code></pre>
-</div>
-</div>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect3">
-<h4 id="accessing-help_cli-guide">2.2.3. Accessing APPCAT help</h4>
-<div class="paragraph">
-<p>To see the complete list of available arguments for the <code>appcat-cli</code> command, open a terminal, navigate to the <code>&lt;APPCAT_HOME&gt;</code> directory, and execute the following command:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli --help</code></pre>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="access-report_cli-guide">3. Accessing reports</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>When you run the Azure Application and Code Assessment Toolkit, a report is generated in the <code>&lt;OUTPUT_REPORT_DIRECTORY&gt;</code> that you specify using the <code>--output</code> argument in the command line.</p>
-</div>
-<div class="paragraph">
-<p>The output directory contains the following files and subdirectories:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="cli-bash-completion_cli-guide">2.2.2. APPCAT CLI Bash completion</h4>
+                    <div class="paragraph">
+                        <p>The APPCAT CLI provides an option to enable Bash completion for Linux systems, allowing the APPCAT command-line arguments to be auto completed by pressing the Tab key when entering the commands. For instance, when Bash completion is enabled, entering the following displays a list of available arguments.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+                            <pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat [TAB]</code></pre>
+                        </div>
+                    </div>
+                    <h5 id="bash-completion-temporary_cli-guide" class="discrete">Enabling Bash completion</h5>
+                    <div class="paragraph">
+                        <p>To enable Bash completion for the current shell, execute the following command:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+                            <pre class="highlight"><code class="language-terminal" data-lang="terminal">$ source &lt;APPCAT_HOME&gt;/bash-completion/appcat</code></pre>
+                        </div>
+                    </div>
+                    <h5 id="bash-completion-persistent_cli-guide" class="discrete">Enabling persistent Bash completion</h5>
+                    <div class="paragraph">
+                        <p>The following commands allow Bash completion to persist across restarts:</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>To enable Bash completion for a specific user across system restarts, include the following line in that user&#8217;s <code>~/.bashrc</code> file.</p>
+                                <div class="listingblock">
+                                    <div class="content">
+                                        <pre class="highlight"><code class="language-terminal" data-lang="terminal">source &lt;APPCAT_HOME&gt;/bash-completion/appcat</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                            <li>
+                                <p>To enable Bash completion for all users across system restarts, copy the Azure Migrate application and code assessment for Java CLI Bash completion file to the <code>/etc/bash_completion.d/</code> directory as the root user.</p>
+                                <div class="listingblock">
+                                    <div class="content">
+                                        <pre class="highlight"><code class="language-terminal" data-lang="terminal"># cp &lt;APPCAT_HOME&gt;/bash-completion/appcat /etc/bash_completion.d/</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="accessing-help_cli-guide">2.2.3. Accessing APPCAT help</h4>
+                    <div class="paragraph">
+                        <p>To see the complete list of available arguments for the <code>appcat</code> command, open a terminal, navigate to the <code>&lt;APPCAT_HOME&gt;</code> directory, and execute the following command:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
+                            <pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat --help</code></pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="access-report_cli-guide">3. Accessing reports</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>When you run the Azure Migrate application and code assessment for Java, a report is generated in the <code>&lt;OUTPUT_REPORT_DIRECTORY&gt;</code> that you specify using the <code>--output</code> argument in the command line.</p>
+            </div>
+            <div class="paragraph">
+                <p>The output directory contains the following files and subdirectories:</p>
+            </div>
+            <div class="listingblock">
+                <div class="content">
 <pre>&lt;OUTPUT_REPORT_DIRECTORY&gt;/
 ├── index.html          // Landing page for the report
 ├── &lt;EXPORT_FILE&gt;.csv   // Optional export of data in CSV format
@@ -819,2507 +819,2507 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 ├── mavenized/          // Optional Maven project structure
 ├── reports/            // Generated HTML reports
 ├── stats/              // Performance statistics</pre>
-</div>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Obtain the path of the <code>index.html</code> file of your report from the output that appears after you run APPCAT:</p>
-<div class="listingblock">
-<div class="content">
+                </div>
+            </div>
+            <div class="olist arabic">
+                <div class="title">Procedure</div>
+                <ol class="arabic">
+                    <li>
+                        <p>Obtain the path of the <code>index.html</code> file of your report from the output that appears after you run APPCAT:</p>
+                        <div class="listingblock">
+                            <div class="content">
 <pre>Report created: &lt;OUTPUT_REPORT_DIRECTORY&gt;/index.html
               Access it at this URL: file:///&lt;OUTPUT_REPORT_DIRECTORY&gt;/index.html</pre>
-</div>
-</div>
-</li>
-<li>
-<p>Open the <code>index.html</code> file by using a browser.</p>
-<div class="paragraph">
-<p>The generated report is displayed.</p>
-</div>
-</li>
-</ol>
-</div>
-<div class="sect2">
-<h3 id="review-reports_cli-guide">3.1. Reviewing the reports</h3>
-<div class="paragraph">
-<p>The report examples shown in the following sections are a result of analyzing the <code>com.acme</code> and <code>org.apache</code> packages in the <a href="https://github.com/windup/windup/blob/master/test-files/jee-example-app-1.0.0.ear">jee-example-app-1.0.0.ear</a> example application, which is located in the APPCAT GitHub source repository.</p>
-</div>
-<div class="paragraph">
-<p>The report was generated using the following command.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli --input /home/username/appcat-cli-source/test-files/jee-example-app-1.0.0.ear/ --output /home/username/appcat-cli-reports/jee-example-app-1.0.0.ear-report --target eap:6 --packages com.acme org.apache</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>Use a browser to open the <code>index.html</code> file located in the report output directory. This opens a landing page that lists the applications that were processed.  Each row contains a high-level overview of the story points, number of incidents, and technologies encountered in that application.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-1-applications.png" alt="Application list">
-</div>
-<div class="title">Figure 1. Application list</div>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-The incidents and estimated story points change as new rules are added to APPCAT. The values here may not match what you see when you test this application.
-</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>The following table lists all of the reports and pages that can be accessed from this main APPCAT landing page. Click the name of the application, <strong>jee-example-app-1.0.0.ear</strong>, to view the application report.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 30%;">
-<col style="width: 70%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Page</th>
-<th class="tableblock halign-left valign-top">How to Access</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Application</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Click the name of the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Technologies report</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Technologies</strong> link at the top of the page.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Archives shared by multiple applications</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Archives shared by multiple applications</strong> link. Note that this link is only available when there are shared archives across multiple applications.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rule providers execution overview</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Rule providers execution overview</strong> link at the bottom of the page.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p>Note that if an application shares archives with other analyzed applications, you will see a breakdown of how many story points are from shared archives and how many are unique to this application.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-2-shared-archives.png" alt="Shared archives">
-</div>
-<div class="title">Figure 2. Shared archives</div>
-</div>
-<div class="paragraph">
-<p>Information about the archives that are shared among applications can be found in the Archives Shared by Multiple Applications reports.</p>
-</div>
-<div class="sect3">
-<h4 id="review-application-report_cli-guide">3.1.1. Application report</h4>
-<div class="sect4">
-<h5 id="_dashboard">Dashboard</h5>
-<div class="paragraph">
-<p>Access this report from the report landing page by clicking on the application name in the <strong>Application List</strong>.</p>
-</div>
-<div class="paragraph">
-<p>The dashboard gives an overview of the entire application migration effort. It summarizes:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>The incidents and story points by category</p>
-</li>
-<li>
-<p>The incidents and story points by level of effort of the suggested changes</p>
-</li>
-<li>
-<p>The incidents by package</p>
-</li>
-</ul>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-3-dashboard.png" alt="Dashboard">
-</div>
-<div class="title">Figure 3. Dashboard</div>
-</div>
-<div class="paragraph">
-<p>The top navigation bar lists the various reports that contain additional details about the migration of this application. Note that only those reports that are applicable to the current application will be available.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 30%;">
-<col style="width: 70%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Report</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Issues</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Provides a concise summary of all issues that require attention.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Application details</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Provides a detailed overview of all resources found within the application that may need attention during the migration.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Technologies</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Displays all embedded libraries grouped by functionality, allowing you to quickly view the technologies used in each application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Dependencies</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Displays all Java-packaged dependencies found within the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unparsable</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Shows all files that APPCAT could not parse in the expected format. For instance, a file with a <code>.xml</code> or <code>.wsdl</code> suffix is assumed to be an XML file. If the XML parser fails, the issue is reported here and also where the individual file is listed.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Remote services</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Displays all remote services references that were found within the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">EJBs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Contains a list of EJBs found within the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">JBPM</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Contains all of the JBPM-related resources that were discovered during analysis.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">JPA</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Contains details on all JPA-related resources that were found in the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hibernate</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Contains details on all Hibernate-related resources that were found in the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Server resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Displays all server resources (for example, JNDI resources) in the input application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spring Beans</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Contains a list of Spring Beans found during the analysis.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hard-coded IP addresses</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Provides a list of all hard-coded IP addresses that were found in the application.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ignored files</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Lists the files found in the application that, based on certain rules and APPCAT configuration, were not processed. See the <code>--userIgnorePath</code> option for more information.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">About</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Describes the current version of APPCAT and provides helpful links for further assistance.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="issues-report_cli-guide">Issues report</h5>
-<div class="paragraph">
-<p>Access this report from the dashboard by clicking the <strong>Issues</strong> link.</p>
-</div>
-<div class="paragraph">
-<p>This report includes details about every issue that was raised by the selected migration paths. The following information is provided for each issue encountered:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>A title to summarize the issue.</p>
-</li>
-<li>
-<p>The total number of incidents, or times the issue was encountered.</p>
-</li>
-<li>
-<p>The rule story points to resolve a single instance of the issue.</p>
-</li>
-<li>
-<p>The estimated level of effort to resolve the issue.</p>
-</li>
-<li>
-<p>The total story points to resolve every instance encountered. This is calculated by multiplying the number of incidents found by the story points per incident.</p>
-</li>
-</ul>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-4-issues-report.png" alt="Issues report">
-</div>
-<div class="title">Figure 4. Issues report</div>
-</div>
-<div class="paragraph">
-<p>Each reported issue may be expanded, by clicking on the title, to obtain additional details. The following information is provided.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>A list of files where the incidents occurred, along with the number of incidents within each file. If the file is a Java source file, then clicking the filename will direct you to the corresponding Source report.</p>
-</li>
-<li>
-<p>A detailed description of the issue. This description outlines the problem, provides any known solutions, and references supporting documentation regarding either the issue or resolution.</p>
-</li>
-<li>
-<p>A direct link, entitled <strong>Show Rule</strong>, to the rule that generated the issue.</p>
-</li>
-</ul>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-5-expanded-issue.png" alt="Expanded rule in the issues report">
-</div>
-<div class="title">Figure 5. Expanded issue</div>
-</div>
-<div class="paragraph">
-<p>Issues are sorted into four categories by default. Information on these categories is available at ask Category.</p>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_application_details_report">Application details report</h5>
-<div class="paragraph">
-<p>Access this report from the dashboard by clicking the <strong>Application Details</strong> link.</p>
-</div>
-<div class="paragraph">
-<p>The report lists the story points, the Java incidents by package, and a count of the occurrences of the technologies found in the application. Next is a display of application messages generated during the migration process. Finally, there is a breakdown of this information for each archive analyzed during the process.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-6-application-details-report.png" alt="Application Details report">
-</div>
-<div class="title">Figure 6. Application Details report</div>
-</div>
-<div class="paragraph">
-<p>Expand the <code>jee-example-app-1.0.0.ear/jee-example-services.jar</code> to review the story points, Java incidents by package, and a count of the occurrences of the technologies found in this archive. This summary begins with a total of the story points assigned to its migration, followed by a table detailing the changes required for each file in the archive. The report contains the following columns.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 75%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Column Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The name of the file being analyzed.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Technology</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The type of file being analyzed, for example, <strong>Decompiled Java File</strong> or <strong>Properties</strong>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Issues</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Warnings about areas of code that need review or changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Story Points</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Level of effort required to migrate the file.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p>Note that if an archive is duplicated several times in an application, it will be listed just once in the report and will be tagged with <code>[Included multiple times]</code>.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-7-duplicate-archive-in-application.png" alt="Duplicate archive">
-</div>
-<div class="title">Figure 7. Duplicate archive in an application</div>
-</div>
-<div class="paragraph">
-<p>The story points for archives that are duplicated within an application will be counted only once in the total story point count for that application.</p>
-</div>
-</div>
-<div class="sect4">
-<h5 id="technology-report-application_cli-guide">Technologies report</h5>
-<div class="paragraph">
-<p>Access this report from the application report dashboard by clicking the <strong>Technologies</strong> tab.</p>
-</div>
-<div class="paragraph">
-<p>The report lists the occurrences of technologies, grouped by function, in the analyzed application. It is an overview of the technologies found in the application, and is designed to assist users in quickly understanding each application&#8217;s purpose.</p>
-</div>
-<div class="paragraph">
-<p>The image below shows the technologies used in the <code>jee-example-app</code>.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-8-technologies-in-application.png" alt="Technology report Application view">
-</div>
-<div class="title">Figure 8. Technologies in an application</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_transactions_report">Transactions report</h5>
-<div class="paragraph">
-<p>A Transactions report displays the call stack, which executes operations on relational database tables. The Enable Transaction Analysis feature supports Spring Data JPA and the traditional <code>preparedStatement()</code> method for SQL statement execution. It does not support ORM frameworks, such as Hibernate.</p>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_source_report">Source report</h5>
-<div class="paragraph">
-<p>The Source report displays the migration issues in the context of the source file in which they were discovered.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-10-source-report.png" alt="Source Report">
-</div>
-<div class="title">Figure 9. Source report</div>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="technology-report_cli-guide">3.1.2. Technologies report across multiple applications</h4>
-<div class="paragraph">
-<p>Access this report from the report landing page by clicking the <strong>Technologies</strong> link.</p>
-</div>
-<div class="paragraph">
-<p>This report provides an aggregate listing of the technologies used, grouped by function, for the analyzed applications. It shows how the technologies are distributed, and is typically reviewed after analyzing a large number of applications to group the applications and identify patterns. It also shows the size, number of libraries, and story point totals of each application.</p>
-</div>
-<div class="paragraph">
-<p>Clicking any of the headers, such as <strong>Markup</strong>, sorts the results in descending order. Selecting the same header again will resort the results in ascending order. The currently selected header is identified in bold, next to a directional arrow, indicating the direction of the sort.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-11-technologies-used-across-multiple-applications.png" alt="Technologies used across multiple applications">
-</div>
-<div class="title">Figure 10. Technologies used across multiple applications</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="shared-archives_cli-guide">3.1.3. Archives shared by multiple applications</h4>
-<div class="paragraph">
-<p>Access these reports from the report landing page by clicking the <strong>Archives shared by multiple applications</strong> link. Note that this link is only available if there are applicable shared archives.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-12-archives-shared-by-multiple-applications.png" alt="Archives shared by multiple applications">
-</div>
-<div class="title">Figure 11. Archives shared by multiple applications</div>
-</div>
-<div class="paragraph">
-<p>This allows you to view the detailed reports for all archives that are shared across multiple applications.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="review-rule-providers-execution-overview_cli-guide">3.1.4. Rule providers execution overview</h4>
-<div class="paragraph">
-<p>Access this report from the report landing page by clicking the <strong>Rule providers execution overview</strong> link.</p>
-</div>
-<div class="paragraph">
-<p>This report provides the list of rules that ran when running the APPCAT migration command against the application.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/3-13-rule-providers-execution-overview.png" alt="Rule Provider Execution Overview">
-</div>
-<div class="title">Figure 12. Rule providers execution overview</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="csv-export_cli-guide">4. Exporting the report in CSV format</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>APPCAT provides the ability to export the report data, including the classifications and hints, to a flat file on your local file system.  The export function currently supports the CSV file format, which presents the report data as fields separated by commas (<code>,</code>).</p>
-</div>
-<div class="paragraph">
-<p>The CSV file can be imported and manipulated by spreadsheet software such as Microsoft Excel, OpenOffice Calc, or LibreOffice Calc. Spreadsheet software provides the ability to sort, analyze, evaluate, and manage the result data from an APPCAT report.</p>
-</div>
-<div class="sect2">
-<h3 id="export-the-report_cli-guide">4.1. Exporting the report</h3>
-<div class="paragraph">
-<p>To export the report as a CSV file, run APPCAT with the <code>--exportCSV</code> argument. A CSV file is created in the directory specified by the <code>--output</code> argument for each application analyzed.</p>
-</div>
-<div class="paragraph">
-<p>All discovered issues, spanning all the analyzed applications, are included in the <code>AllIssues.csv</code> file that is exported to the root directory of the report.</p>
-</div>
-<h4 id="_accessing_the_report_from_the_application_report" class="discrete">Accessing the report from the application report</h4>
-<div class="paragraph">
-<p>If you have exported the CSV report, you can download all of the CSV issues in the Issues Report. To download these issues, click <strong>Download All Issues CSV</strong> in the Issues Report.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/4-1-issues-report-with-csv-download.png" alt="Issues report with CSV download">
-</div>
-<div class="title">Figure 13. Issues report with CSV download</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_importing_the_csv_file_into_a_spreadsheet_program">4.2. Importing the CSV file into a spreadsheet program</h3>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Launch the spreadsheet software, for example, Microsoft Excel.</p>
-</li>
-<li>
-<p>Choose <strong>File</strong> &#8594; <strong>Open</strong>.</p>
-</li>
-<li>
-<p>Browse to the CSV exported file and select it.</p>
-</li>
-<li>
-<p>The data is now ready to analyze in the spreadsheet software.</p>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_about_the_csv_data_structure">4.3. About the CSV data structure</h3>
-<div class="paragraph">
-<p>The CSV formatted output file contains the following data fields:</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">Rule Id</dt>
-<dd>
-<p>The ID of the rule that generated the given item.</p>
-</dd>
-<dt class="hdlist1">Problem type</dt>
-<dd>
-<p><em>hint</em> or <em>classification</em></p>
-</dd>
-<dt class="hdlist1">Title</dt>
-<dd>
-<p>The title of the <em>classification</em> or <em>hint</em>. This field summarizes the issue for the given item.</p>
-</dd>
-<dt class="hdlist1">Description</dt>
-<dd>
-<p>The detailed description of the issue for the given item.</p>
-</dd>
-<dt class="hdlist1">Links</dt>
-<dd>
-<p>URLs that provide additional information about the issue. A link consists of two attributes: the link and a description of the link.</p>
-</dd>
-<dt class="hdlist1">Application</dt>
-<dd>
-<p>The name of the application for which this item was generated.</p>
-</dd>
-<dt class="hdlist1">File Name</dt>
-<dd>
-<p>The name of the file for the given item.</p>
-</dd>
-<dt class="hdlist1">File Path</dt>
-<dd>
-<p>The file path for the given item.</p>
-</dd>
-<dt class="hdlist1">Line</dt>
-<dd>
-<p>The line number of the file for the given item.</p>
-</dd>
-<dt class="hdlist1">Story points</dt>
-<dd>
-<p>The number of story points, which represent the level of effort, assigned to the given item.</p>
-</dd>
-</dl>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="optimize-performance_cli-guide">5. Optimizing APPCAT performance</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>APPCAT performance depends on a number of factors, including hardware configuration, the number and types of files in the application, the size and number of applications to be evaluated, and whether the application contains source or compiled code. For example, a file that is larger than 10 MB may need a lot of time to process.</p>
-</div>
-<div class="paragraph">
-<p>In general, APPCAT spends about 40% of the time decompiling classes, 40% of the time executing rules, and the remainder of the time processing other tasks and generating reports. This section describes what you can do to improve the performance of APPCAT.</p>
-</div>
-<div class="sect2">
-<h3 id="_deploying_and_running_the_application">5.1. Deploying and running the application</h3>
-<div class="paragraph">
-<p>Try these suggestions first before upgrading hardware.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>If possible, run APPCAT against the source code instead of the archives. This eliminates the need to decompile additional JARs and archives.</p>
-</li>
-<li>
-<p>Specify a comma-separated list of the packages to be evaluated by APPCAT using the <code>--packages</code> argument on the <code>&lt;APPCAT_HOME&gt;/bin/appcat-cli</code> command line. If you omit this argument, APPCAT will decompile everything, which has a big impact on performance.</p>
-</li>
-<li>
-<p>Specify the <code>--excludeTags</code> argument where possible to exclude them from processing.</p>
-</li>
-<li>
-<p>Avoid decompiling and analyzing any unnecessary packages and files, such as proprietary packages or included dependencies.</p>
-</li>
-<li>
-<p>Increase your ulimit when analyzing large applications on a Linux-like envrionment.</p>
-</li>
-<li>
-<p>If you have access to a server that has better resources than your laptop or desktop machine, you may want to consider running APPCAT on that server.</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_upgrading_hardware">5.2. Upgrading hardware</h3>
-<div class="paragraph">
-<p>If the application and command-line suggestions above do not improve performance, you may need to upgrade your hardware.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>If you have access to a server that has better resources than your laptop/desktop, then you may want to consider running APPCAT on that server.</p>
-</li>
-<li>
-<p>Very large applications that require decompilation have large memory requirements. 8 GB RAM is recommended. This allows 3 - 4 GB RAM for use by the JVM.</p>
-</li>
-<li>
-<p>An upgrade from a single or dual-core to a quad-core CPU processor provides better performance.</p>
-</li>
-<li>
-<p>Disk space and fragmentation can impact performance. A fast disk, especially a solid-state drive (SSD), with greater than 4 GB of defragmented disk space should improve performance.</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect2">
-<h3 id="exclude-files-and-packages_cli-guide">5.3. Configuring APPCAT to exclude packages and files</h3>
-<div class="sect3">
-<h4 id="exclude-packages_cli-guide">5.3.1. Excluding packages</h4>
-<div class="paragraph">
-<p>You can exclude packages during decompilation and analysis to increase performance. References to these packages remain in the application&#8217;s source code but excluding them avoids the decompilation and analysis of proprietary classes.</p>
-</div>
-<div class="paragraph">
-<p>Any packages that match the defined value are excluded. For example, you can use <code>com.acme</code> to exclude both <code>com.acme.example</code> and <code>com.acme.roadrunner</code>.</p>
-</div>
-<div class="paragraph">
-<p>You can exclude packages by either of the following methods:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>Using the <code>--excludePackages</code> argument.</p>
-</li>
-<li>
-<p>Specifying the packages in a file contained within one of the ignored locations. Each package should be included on a separate line, and the file must end in <code>.package-ignore.txt</code>. For example, see <code>&lt;APPCAT_HOME&gt;/ignore/proprietary.package-ignore.txt</code>.</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect3">
-<h4 id="exclude-files_cli-guide">5.3.2. Excluding files</h4>
-<div class="paragraph">
-<p>APPCAT can exclude specific files, such as included libraries or dependencies, during scanning and report generation. Excluded files are defined in a file with the <code>.appcat-ignore.txt</code> or <code>.windup-ignore.txt</code> extension within one of the ignored locations.</p>
-</div>
-<div class="paragraph">
-<p>These files contain a regex string detailing the name to exclude, with one file listed per line. For example, you can exclude the library <code>ant.jar</code> and any Java source files beginning with <code>Example</code> with a file containing the following:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                            </div>
+                        </div>
+                    </li>
+                    <li>
+                        <p>Open the <code>index.html</code> file by using a browser.</p>
+                        <div class="paragraph">
+                            <p>The generated report is displayed.</p>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+            <div class="sect2">
+                <h3 id="review-reports_cli-guide">3.1. Reviewing the reports</h3>
+                <div class="paragraph">
+                    <p>The report examples shown in the following sections are a result of analyzing the <code>com.acme</code> and <code>org.apache</code> packages in the <a href="https://github.com/windup/windup/blob/master/test-files/jee-example-app-1.0.0.ear">jee-example-app-1.0.0.ear</a> example application, which is located in the APPCAT GitHub source repository.</p>
+                </div>
+                <div class="paragraph">
+                    <p>The report was generated using the following command.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="nowrap">$ &lt;APPCAT_HOME&gt;/bin/appcat --input /home/username/appcat-cli-source/test-files/jee-example-app-1.0.0.ear/ --output /home/username/appcat-cli-reports/jee-example-app-1.0.0.ear-report --target eap:6 --packages com.acme org.apache</pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>Use a browser to open the <code>index.html</code> file located in the report output directory. This opens a landing page that lists the applications that were processed.  Each row contains a high-level overview of the story points, number of incidents, and technologies encountered in that application.</p>
+                </div>
+                <div class="imageblock">
+                    <div class="content">
+                        <img src="topics/images/3-1-applications.png" alt="Application list">
+                    </div>
+                    <div class="title">Figure 1. Application list</div>
+                </div>
+                <div class="admonitionblock note">
+                    <table>
+                        <tr>
+                            <td class="icon">
+                                <div class="title">Note</div>
+                            </td>
+                            <td class="content">
+                                The incidents and estimated story points change as new rules are added to APPCAT. The values here may not match what you see when you test this application.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="paragraph">
+                    <p>The following table lists all of the reports and pages that can be accessed from this main APPCAT landing page. Click the name of the application, <strong>jee-example-app-1.0.0.ear</strong>, to view the application report.</p>
+                </div>
+                <table class="tableblock frame-all grid-all stretch">
+                    <colgroup>
+                        <col style="width: 30%;">
+                        <col style="width: 70%;">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                        <th class="tableblock halign-left valign-top">Page</th>
+                        <th class="tableblock halign-left valign-top">How to Access</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Application</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Click the name of the application.</p></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Technologies report</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Technologies</strong> link at the top of the page.</p></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Archives shared by multiple applications</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Archives shared by multiple applications</strong> link. Note that this link is only available when there are shared archives across multiple applications.</p></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Rule providers execution overview</p></td>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">Click the <strong>Rule providers execution overview</strong> link at the bottom of the page.</p></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <div class="paragraph">
+                    <p>Note that if an application shares archives with other analyzed applications, you will see a breakdown of how many story points are from shared archives and how many are unique to this application.</p>
+                </div>
+                <div class="imageblock">
+                    <div class="content">
+                        <img src="topics/images/3-2-shared-archives.png" alt="Shared archives">
+                    </div>
+                    <div class="title">Figure 2. Shared archives</div>
+                </div>
+                <div class="paragraph">
+                    <p>Information about the archives that are shared among applications can be found in the Archives Shared by Multiple Applications reports.</p>
+                </div>
+                <div class="sect3">
+                    <h4 id="review-application-report_cli-guide">3.1.1. Application report</h4>
+                    <div class="sect4">
+                        <h5 id="_dashboard">Dashboard</h5>
+                        <div class="paragraph">
+                            <p>Access this report from the report landing page by clicking on the application name in the <strong>Application List</strong>.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The dashboard gives an overview of the entire application migration effort. It summarizes:</p>
+                        </div>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p>The incidents and story points by category</p>
+                                </li>
+                                <li>
+                                    <p>The incidents and story points by level of effort of the suggested changes</p>
+                                </li>
+                                <li>
+                                    <p>The incidents by package</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-3-dashboard.png" alt="Dashboard">
+                            </div>
+                            <div class="title">Figure 3. Dashboard</div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The top navigation bar lists the various reports that contain additional details about the migration of this application. Note that only those reports that are applicable to the current application will be available.</p>
+                        </div>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 30%;">
+                                <col style="width: 70%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Report</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Issues</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Provides a concise summary of all issues that require attention.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Application details</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Provides a detailed overview of all resources found within the application that may need attention during the migration.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Technologies</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Displays all embedded libraries grouped by functionality, allowing you to quickly view the technologies used in each application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Dependencies</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Displays all Java-packaged dependencies found within the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Unparsable</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Shows all files that APPCAT could not parse in the expected format. For instance, a file with a <code>.xml</code> or <code>.wsdl</code> suffix is assumed to be an XML file. If the XML parser fails, the issue is reported here and also where the individual file is listed.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Remote services</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Displays all remote services references that were found within the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">EJBs</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Contains a list of EJBs found within the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">JBPM</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Contains all of the JBPM-related resources that were discovered during analysis.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">JPA</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Contains details on all JPA-related resources that were found in the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Hibernate</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Contains details on all Hibernate-related resources that were found in the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Server resources</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Displays all server resources (for example, JNDI resources) in the input application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Spring Beans</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Contains a list of Spring Beans found during the analysis.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Hard-coded IP addresses</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Provides a list of all hard-coded IP addresses that were found in the application.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Ignored files</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Lists the files found in the application that, based on certain rules and APPCAT configuration, were not processed. See the <code>--userIgnorePath</code> option for more information.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">About</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Describes the current version of APPCAT and provides helpful links for further assistance.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="issues-report_cli-guide">Issues report</h5>
+                        <div class="paragraph">
+                            <p>Access this report from the dashboard by clicking the <strong>Issues</strong> link.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>This report includes details about every issue that was raised by the selected migration paths. The following information is provided for each issue encountered:</p>
+                        </div>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p>A title to summarize the issue.</p>
+                                </li>
+                                <li>
+                                    <p>The total number of incidents, or times the issue was encountered.</p>
+                                </li>
+                                <li>
+                                    <p>The rule story points to resolve a single instance of the issue.</p>
+                                </li>
+                                <li>
+                                    <p>The estimated level of effort to resolve the issue.</p>
+                                </li>
+                                <li>
+                                    <p>The total story points to resolve every instance encountered. This is calculated by multiplying the number of incidents found by the story points per incident.</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-4-issues-report.png" alt="Issues report">
+                            </div>
+                            <div class="title">Figure 4. Issues report</div>
+                        </div>
+                        <div class="paragraph">
+                            <p>Each reported issue may be expanded, by clicking on the title, to obtain additional details. The following information is provided.</p>
+                        </div>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p>A list of files where the incidents occurred, along with the number of incidents within each file. If the file is a Java source file, then clicking the filename will direct you to the corresponding Source report.</p>
+                                </li>
+                                <li>
+                                    <p>A detailed description of the issue. This description outlines the problem, provides any known solutions, and references supporting documentation regarding either the issue or resolution.</p>
+                                </li>
+                                <li>
+                                    <p>A direct link, entitled <strong>Show Rule</strong>, to the rule that generated the issue.</p>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-5-expanded-issue.png" alt="Expanded rule in the issues report">
+                            </div>
+                            <div class="title">Figure 5. Expanded issue</div>
+                        </div>
+                        <div class="paragraph">
+                            <p>Issues are sorted into four categories by default. Information on these categories is available at ask Category.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_application_details_report">Application details report</h5>
+                        <div class="paragraph">
+                            <p>Access this report from the dashboard by clicking the <strong>Application Details</strong> link.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The report lists the story points, the Java incidents by package, and a count of the occurrences of the technologies found in the application. Next is a display of application messages generated during the migration process. Finally, there is a breakdown of this information for each archive analyzed during the process.</p>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-6-application-details-report.png" alt="Application Details report">
+                            </div>
+                            <div class="title">Figure 6. Application Details report</div>
+                        </div>
+                        <div class="paragraph">
+                            <p>Expand the <code>jee-example-app-1.0.0.ear/jee-example-services.jar</code> to review the story points, Java incidents by package, and a count of the occurrences of the technologies found in this archive. This summary begins with a total of the story points assigned to its migration, followed by a table detailing the changes required for each file in the archive. The report contains the following columns.</p>
+                        </div>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 25%;">
+                                <col style="width: 75%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Column Name</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Name</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The name of the file being analyzed.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Technology</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The type of file being analyzed, for example, <strong>Decompiled Java File</strong> or <strong>Properties</strong>.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Issues</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Warnings about areas of code that need review or changes.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Story Points</p></td>
+                                <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                    <p>Level of effort required to migrate the file.</p>
+                                </div></div></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        <div class="paragraph">
+                            <p>Note that if an archive is duplicated several times in an application, it will be listed just once in the report and will be tagged with <code>[Included multiple times]</code>.</p>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-7-duplicate-archive-in-application.png" alt="Duplicate archive">
+                            </div>
+                            <div class="title">Figure 7. Duplicate archive in an application</div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The story points for archives that are duplicated within an application will be counted only once in the total story point count for that application.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="technology-report-application_cli-guide">Technologies report</h5>
+                        <div class="paragraph">
+                            <p>Access this report from the application report dashboard by clicking the <strong>Technologies</strong> tab.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The report lists the occurrences of technologies, grouped by function, in the analyzed application. It is an overview of the technologies found in the application, and is designed to assist users in quickly understanding each application&#8217;s purpose.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The image below shows the technologies used in the <code>jee-example-app</code>.</p>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-8-technologies-in-application.png" alt="Technology report Application view">
+                            </div>
+                            <div class="title">Figure 8. Technologies in an application</div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_transactions_report">Transactions report</h5>
+                        <div class="paragraph">
+                            <p>A Transactions report displays the call stack, which executes operations on relational database tables. The Enable Transaction Analysis feature supports Spring Data JPA and the traditional <code>preparedStatement()</code> method for SQL statement execution. It does not support ORM frameworks, such as Hibernate.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="_source_report">Source report</h5>
+                        <div class="paragraph">
+                            <p>The Source report displays the migration issues in the context of the source file in which they were discovered.</p>
+                        </div>
+                        <div class="imageblock">
+                            <div class="content">
+                                <img src="topics/images/3-10-source-report.png" alt="Source Report">
+                            </div>
+                            <div class="title">Figure 9. Source report</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="technology-report_cli-guide">3.1.2. Technologies report across multiple applications</h4>
+                    <div class="paragraph">
+                        <p>Access this report from the report landing page by clicking the <strong>Technologies</strong> link.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>This report provides an aggregate listing of the technologies used, grouped by function, for the analyzed applications. It shows how the technologies are distributed, and is typically reviewed after analyzing a large number of applications to group the applications and identify patterns. It also shows the size, number of libraries, and story point totals of each application.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>Clicking any of the headers, such as <strong>Markup</strong>, sorts the results in descending order. Selecting the same header again will resort the results in ascending order. The currently selected header is identified in bold, next to a directional arrow, indicating the direction of the sort.</p>
+                    </div>
+                    <div class="imageblock">
+                        <div class="content">
+                            <img src="topics/images/3-11-technologies-used-across-multiple-applications.png" alt="Technologies used across multiple applications">
+                        </div>
+                        <div class="title">Figure 10. Technologies used across multiple applications</div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="shared-archives_cli-guide">3.1.3. Archives shared by multiple applications</h4>
+                    <div class="paragraph">
+                        <p>Access these reports from the report landing page by clicking the <strong>Archives shared by multiple applications</strong> link. Note that this link is only available if there are applicable shared archives.</p>
+                    </div>
+                    <div class="imageblock">
+                        <div class="content">
+                            <img src="topics/images/3-12-archives-shared-by-multiple-applications.png" alt="Archives shared by multiple applications">
+                        </div>
+                        <div class="title">Figure 11. Archives shared by multiple applications</div>
+                    </div>
+                    <div class="paragraph">
+                        <p>This allows you to view the detailed reports for all archives that are shared across multiple applications.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="review-rule-providers-execution-overview_cli-guide">3.1.4. Rule providers execution overview</h4>
+                    <div class="paragraph">
+                        <p>Access this report from the report landing page by clicking the <strong>Rule providers execution overview</strong> link.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>This report provides the list of rules that ran when running the APPCAT migration command against the application.</p>
+                    </div>
+                    <div class="imageblock">
+                        <div class="content">
+                            <img src="topics/images/3-13-rule-providers-execution-overview.png" alt="Rule Provider Execution Overview">
+                        </div>
+                        <div class="title">Figure 12. Rule providers execution overview</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="csv-export_cli-guide">4. Exporting the report in CSV format</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>APPCAT provides the ability to export the report data, including the classifications and hints, to a flat file on your local file system.  The export function currently supports the CSV file format, which presents the report data as fields separated by commas (<code>,</code>).</p>
+            </div>
+            <div class="paragraph">
+                <p>The CSV file can be imported and manipulated by spreadsheet software such as Microsoft Excel, OpenOffice Calc, or LibreOffice Calc. Spreadsheet software provides the ability to sort, analyze, evaluate, and manage the result data from an APPCAT report.</p>
+            </div>
+            <div class="sect2">
+                <h3 id="export-the-report_cli-guide">4.1. Exporting the report</h3>
+                <div class="paragraph">
+                    <p>To export the report as a CSV file, run APPCAT with the <code>--exportCSV</code> argument. A CSV file is created in the directory specified by the <code>--output</code> argument for each application analyzed.</p>
+                </div>
+                <div class="paragraph">
+                    <p>All discovered issues, spanning all the analyzed applications, are included in the <code>AllIssues.csv</code> file that is exported to the root directory of the report.</p>
+                </div>
+                <h4 id="_accessing_the_report_from_the_application_report" class="discrete">Accessing the report from the application report</h4>
+                <div class="paragraph">
+                    <p>If you have exported the CSV report, you can download all of the CSV issues in the Issues Report. To download these issues, click <strong>Download All Issues CSV</strong> in the Issues Report.</p>
+                </div>
+                <div class="imageblock">
+                    <div class="content">
+                        <img src="topics/images/4-1-issues-report-with-csv-download.png" alt="Issues report with CSV download">
+                    </div>
+                    <div class="title">Figure 13. Issues report with CSV download</div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_importing_the_csv_file_into_a_spreadsheet_program">4.2. Importing the CSV file into a spreadsheet program</h3>
+                <div class="olist arabic">
+                    <ol class="arabic">
+                        <li>
+                            <p>Launch the spreadsheet software, for example, Microsoft Excel.</p>
+                        </li>
+                        <li>
+                            <p>Choose <strong>File</strong> &#8594; <strong>Open</strong>.</p>
+                        </li>
+                        <li>
+                            <p>Browse to the CSV exported file and select it.</p>
+                        </li>
+                        <li>
+                            <p>The data is now ready to analyze in the spreadsheet software.</p>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_about_the_csv_data_structure">4.3. About the CSV data structure</h3>
+                <div class="paragraph">
+                    <p>The CSV formatted output file contains the following data fields:</p>
+                </div>
+                <div class="dlist">
+                    <dl>
+                        <dt class="hdlist1">Rule Id</dt>
+                        <dd>
+                            <p>The ID of the rule that generated the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">Problem type</dt>
+                        <dd>
+                            <p><em>hint</em> or <em>classification</em></p>
+                        </dd>
+                        <dt class="hdlist1">Title</dt>
+                        <dd>
+                            <p>The title of the <em>classification</em> or <em>hint</em>. This field summarizes the issue for the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">Description</dt>
+                        <dd>
+                            <p>The detailed description of the issue for the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">Links</dt>
+                        <dd>
+                            <p>URLs that provide additional information about the issue. A link consists of two attributes: the link and a description of the link.</p>
+                        </dd>
+                        <dt class="hdlist1">Application</dt>
+                        <dd>
+                            <p>The name of the application for which this item was generated.</p>
+                        </dd>
+                        <dt class="hdlist1">File Name</dt>
+                        <dd>
+                            <p>The name of the file for the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">File Path</dt>
+                        <dd>
+                            <p>The file path for the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">Line</dt>
+                        <dd>
+                            <p>The line number of the file for the given item.</p>
+                        </dd>
+                        <dt class="hdlist1">Story points</dt>
+                        <dd>
+                            <p>The number of story points, which represent the level of effort, assigned to the given item.</p>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="optimize-performance_cli-guide">5. Optimizing APPCAT performance</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>APPCAT performance depends on a number of factors, including hardware configuration, the number and types of files in the application, the size and number of applications to be evaluated, and whether the application contains source or compiled code. For example, a file that is larger than 10 MB may need a lot of time to process.</p>
+            </div>
+            <div class="paragraph">
+                <p>In general, APPCAT spends about 40% of the time decompiling classes, 40% of the time executing rules, and the remainder of the time processing other tasks and generating reports. This section describes what you can do to improve the performance of APPCAT.</p>
+            </div>
+            <div class="sect2">
+                <h3 id="_deploying_and_running_the_application">5.1. Deploying and running the application</h3>
+                <div class="paragraph">
+                    <p>Try these suggestions first before upgrading hardware.</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>If possible, run APPCAT against the source code instead of the archives. This eliminates the need to decompile additional JARs and archives.</p>
+                        </li>
+                        <li>
+                            <p>Specify a comma-separated list of the packages to be evaluated by APPCAT using the <code>--packages</code> argument on the <code>&lt;APPCAT_HOME&gt;/bin/appcat</code> command line. If you omit this argument, APPCAT will decompile everything, which has a big impact on performance.</p>
+                        </li>
+                        <li>
+                            <p>Specify the <code>--excludeTags</code> argument where possible to exclude them from processing.</p>
+                        </li>
+                        <li>
+                            <p>Avoid decompiling and analyzing any unnecessary packages and files, such as proprietary packages or included dependencies.</p>
+                        </li>
+                        <li>
+                            <p>Increase your ulimit when analyzing large applications on a Linux-like envrionment.</p>
+                        </li>
+                        <li>
+                            <p>If you have access to a server that has better resources than your laptop or desktop machine, you may want to consider running APPCAT on that server.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_upgrading_hardware">5.2. Upgrading hardware</h3>
+                <div class="paragraph">
+                    <p>If the application and command-line suggestions above do not improve performance, you may need to upgrade your hardware.</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>If you have access to a server that has better resources than your laptop/desktop, then you may want to consider running APPCAT on that server.</p>
+                        </li>
+                        <li>
+                            <p>Very large applications that require decompilation have large memory requirements. 8 GB RAM is recommended. This allows 3 - 4 GB RAM for use by the JVM.</p>
+                        </li>
+                        <li>
+                            <p>An upgrade from a single or dual-core to a quad-core CPU processor provides better performance.</p>
+                        </li>
+                        <li>
+                            <p>Disk space and fragmentation can impact performance. A fast disk, especially a solid-state drive (SSD), with greater than 4 GB of defragmented disk space should improve performance.</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="exclude-files-and-packages_cli-guide">5.3. Configuring APPCAT to exclude packages and files</h3>
+                <div class="sect3">
+                    <h4 id="exclude-packages_cli-guide">5.3.1. Excluding packages</h4>
+                    <div class="paragraph">
+                        <p>You can exclude packages during decompilation and analysis to increase performance. References to these packages remain in the application&#8217;s source code but excluding them avoids the decompilation and analysis of proprietary classes.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>Any packages that match the defined value are excluded. For example, you can use <code>com.acme</code> to exclude both <code>com.acme.example</code> and <code>com.acme.roadrunner</code>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>You can exclude packages by either of the following methods:</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>Using the <code>--excludePackages</code> argument.</p>
+                            </li>
+                            <li>
+                                <p>Specifying the packages in a file contained within one of the ignored locations. Each package should be included on a separate line, and the file must end in <code>.package-ignore.txt</code>. For example, see <code>&lt;APPCAT_HOME&gt;/ignore/proprietary.package-ignore.txt</code>.</p>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="exclude-files_cli-guide">5.3.2. Excluding files</h4>
+                    <div class="paragraph">
+                        <p>APPCAT can exclude specific files, such as included libraries or dependencies, during scanning and report generation. Excluded files are defined in a file with the <code>.appcat-ignore.txt</code> or <code>.windup-ignore.txt</code> extension within one of the ignored locations.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>These files contain a regex string detailing the name to exclude, with one file listed per line. For example, you can exclude the library <code>ant.jar</code> and any Java source files beginning with <code>Example</code> with a file containing the following:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
 <pre>.*ant.jar
 .*Example.*\.java</pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="ignored-locations_cli-guide">5.3.3. Searching locations for exclusion</h4>
-<div class="paragraph">
-<p>APPCAT searches the following locations:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>~/.appcat/ignore/</code></p>
-</li>
-<li>
-<p><code>~/.windup/ignore/</code></p>
-</li>
-<li>
-<p><code>&lt;APPCAT_HOME&gt;/ignore/</code></p>
-</li>
-<li>
-<p>Any files and folders specified by the <code>--userIgnorePath</code> argument</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>Each of these files must conform to the rules specified for excluding packages or files, depending on the type of content to be excluded.</p>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_reference_material">Appendix A: Reference material</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="cli-args_cli-guide">A.1. About APPCAT command-line arguments</h3>
-<div class="paragraph">
-<p>The following is a detailed description of the available APPCAT command line arguments.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>To run the APPCAT command without prompting, for example when executing from a script, you must use the following arguments:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>--batchMode</code></p>
-</li>
-<li>
-<p><code>--overwrite</code></p>
-</li>
-<li>
-<p><code>--input</code></p>
-</li>
-<li>
-<p><code>--target</code></p>
-</li>
-</ul>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. APPCAT CLI arguments</caption>
-<colgroup>
-<col style="width: 40%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Argument</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--additionalClassPath</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of additional JAR files or directories to add to the class path so that they are available for decompilation or other analysis.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--addonDir</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Add the specified directory as a custom add-on repository.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--analyzeKnownLibraries</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to analyze known software artifacts embedded within your application. By default, APPCAT only analyzes application code.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>This option may result in a longer execution time and a large number of migration issues being reported.</p>
-</div>
-</td>
-</tr>
-</table>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--batchMode</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to specify that APPCAT should be run in a non-interactive mode without prompting for confirmation. This mode takes the default values for any parameters not passed in to the command line.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--debug</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to run APPCAT in debug mode.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--disableTattletale</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to disable generation of the Tattletale report. If both <code>enableTattletale</code> and <code>disableTattletale</code> are set to true, then <code>disableTattletale</code> will be ignored and the Tattletale report will still be generated.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--discoverPackages</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to list all available packages in the input binary application.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--enableClassNotFoundAnalysis</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to enable analysis of Java files that are not available on the class path. This should not be used if some classes will be unavailable at analysis time.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--enableCompatibleFilesReport</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to enable generation of the Compatible Files report. Due to processing all files without found issues, this report may take a long time for large applications.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--enableTattletale</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to enable generation of a Tattletale report for each application. This option is enabled by default when <code>eap</code> is in the included target. If both <code>enableTattletale</code> and <code>disableTattletale</code> are set to true, then <code>disableTattletale</code> will be ignored and the Tattletale report will still be generated.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--enableTransactionAnalysis</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>[Technology Preview] Flag to enable generation of a Transactions report that displays the call stack, which executes operations on relational database tables. The Enable Transaction Analysis feature supports Spring Data JPA and the traditional <code>preparedStatement()</code> method for SQL statement execution. It does not support ORM frameworks, such as Hibernate.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>enableTransactionAnalysis is a Technology Preview feature only. Technology Preview features are not supported with any service level agreements (SLAs) and might not be functionally complete. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.</p>
-</div>
-</td>
-</tr>
-</table>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--excludePackages</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of packages to exclude from evaluation. For example, entering <code>com.mycompany.commonutilities</code> excludes all classes whose package names begin with <code>com.mycompany.commonutilities</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--excludeTags</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of tags to exclude. When specified, rules with these tags will not be processed. To see the full list of tags, use the <code>--listTags</code> argument.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--explodedApp</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to indicate that the provided input directory contains source files for a single application.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--exportCSV</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to export the report data to a CSV file on your local file system. APPCAT creates the file in the directory specified by the <code>--output</code> argument. The CSV file can be imported into a spreadsheet program for data manipulation and analysis.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--exportSummary</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to instruct APPCAT to generate an <code>analysisSummary.json</code> export file in the output directory. The file contains analysis summary information for each application analyzed, including the number of incidents and story points by category, and all of the technology tags associated with the analyzed applications.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--exportZipReport</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>This argument creates a <code>reports.zip</code> file in the output folder. The file contains the analysis output, typically, the reports. If requested, it can also contain the CSV export files.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--help</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Display the APPCAT help message.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--immutableAddonDir</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Add the specified directory as a custom read-only add-on repository.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--includeTags</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of tags to use. When specified, only rules with these tags will be processed. To see the full list of tags, use the <code>--listTags</code> argument.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--input</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of the path to the file or directory containing one or more applications to be analyzed. This argument is required.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--install</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify add-ons to install. The syntax is <code>&lt;GROUP_ID&gt;:&lt;ARTIFACT_ID&gt;[:&lt;VERSION&gt;]</code>. For example, <code>--install core-addon-x</code> or <code>--install org.example.addon:example:1.0.0</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--keepWorkDirs</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to instruct APPCAT to not delete temporary working files, such as the graph database and extracted archive files. This is useful for debugging purposes.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--legacyReports</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to instruct APPCAT to generate the old format reports instead of the new format reports.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--list</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to list installed add-ons.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--listSourceTechnologies</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to list all available source technologies.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--listTags</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to list all available tags.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--listTargetTechnologies</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to list all available target technologies.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--mavenize</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to create a Maven project directory structure based on the structure and content of the application. This creates <code>pom.xml</code> files using the appropriate Java EE API and the correct dependencies between project modules. See also the <code>--mavenizeGroupId</code> option.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--mavenizeGroupId</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>When used with the <code>--mavenize</code> option, all generated <code>pom.xml</code> files will use the provided value for their <code>&lt;groupId&gt;</code>. If this argument is omitted, APPCAT will attempt to determine an appropriate <code>&lt;groupId&gt;</code> based on the application, or will default to <code>com.mycompany.mavenized</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--online</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to allow network access for features that require it. Currently only validating XML schemas against external resources relies on Internet access. Note that this comes with a performance penalty.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--output</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify the path to the directory to output the report information generated by APPCAT.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--overwrite</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to force delete the existing output directory specified by <code>--output</code>. If you do not specify this argument and the <code>--output</code> directory exists, you are prompted to choose whether to overwrite the contents.</p>
-</div>
-<div class="admonitionblock important">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Important</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>Do not overwrite a report output directory that contains important information.</p>
-</div>
-</td>
-</tr>
-</table>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--packages</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of the packages to be evaluated by APPCAT. It is highly recommended to use this argument.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--remove</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Remove the specified add-ons. The syntax is <code>&lt;GROUP_ID&gt;:&lt;ARTIFACT_ID&gt;[:&lt;VERSION&gt;]</code>. For example, <code>--remove core-addon-x</code> or <code>--remove org.example.addon:example:1.0.0</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--skipReports</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to indicate that HTML reports should not be generated. A common use of this argument is when exporting report data to a CSV file using <code>--exportCSV</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--source</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of one or more source technologies, servers, platforms, or frameworks to migrate from. This argument, in conjunction with the <code>--target</code> argument, helps to determine which rulesets are used. Use the <code>--listSourceTechnologies</code> argument to list all available sources.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--sourceMode</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Flag to indicate that the application to be evaluated contains source files rather than compiled binaries. The sourceMode argument has been deprecated. There is no longer the need to specify it. APPCAT can intuitively process any inputs that are presented to it.  In addition, project source folders can be analyzed with binary inputs within the same analysis execution.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--target</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A space-delimited list of one or more target technologies, servers, platforms, or frameworks to migrate to. This argument, in conjunction with the <code>--source</code> argument, helps to determine which rulesets are used. Use the <code>--listTargetTechnologies</code> argument to list all available targets.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--userIgnorePath</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify a location, in addition to <code>${user.home}/.appcat/ignore/</code>, for APPCAT to identify files that should be ignored.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--userLabelsDirectory</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify a location for APPCAT to look for custom Target Runtime Labels. The value can be a directory containing label files or a single label file. The Target Runtime Label files must use the <code>.windup.label.xml</code> suffix. The shipped Target Runtime Labels are defined within <code>$APPCAT_HOME/rules/migration-core/core.windup.label.xml</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--userRulesDirectory</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify a location, in addition to <code>&lt;APPCAT_HOME&gt;/rules/</code> and <code>${user.home}/.appcat/rules/</code>, for APPCAT to look for custom APPCAT rules. The value can be a directory containing ruleset files or a single ruleset file. The ruleset files must use the <code>.windup.xml</code> suffix.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--version</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Display the APPCAT version.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">--skipSourceCodeReports</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>This option skips generating a <em>Source code report</em> when generating the application analysis report. Use this advanced option when concerned about source code information appearing in the application analysis.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-<div class="sect3">
-<h4 id="cli-input-argument_cli-guide">A.1.1. Specifying the input</h4>
-<div class="paragraph">
-<p>A space-delimited list of the path to the file or directory containing one or more applications to be analyzed. This argument is required.</p>
-</div>
-<div class="listingblock">
-<div class="title">Usage</div>
-<div class="content">
-<pre class="highlight nowrap"><code>--input &lt;INPUT_ARCHIVE_OR_DIRECTORY&gt; [...]</code></pre>
-</div>
-</div>
-<div id="cli-input-file-type-arguments_cli-guide" class="paragraph">
-<p>Depending on whether the input file type provided to the <code>--input</code> argument is a file or directory, it will be evaluated as follows depending on the additional arguments provided.</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">Directory</dt>
-<dd>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">--explodedApp</th>
-<th class="tableblock halign-left valign-top">--sourceMode</th>
-<th class="tableblock halign-left valign-top">Neither Argument</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The directory is evaluated as a single application.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The directory is evaluated as a single application.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Each subdirectory is evaluated as an application.</p></td>
-</tr>
-</tbody>
-</table>
-</dd>
-<dt class="hdlist1">File</dt>
-<dd>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">--explodedApp</th>
-<th class="tableblock halign-left valign-top">--sourceMode</th>
-<th class="tableblock halign-left valign-top">Neither Argument</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Argument is ignored; the file is evaluated as a single application.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The file is evaluated as a compressed project.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The file is evaluated as a single application.</p></td>
-</tr>
-</tbody>
-</table>
-</dd>
-</dl>
-</div>
-</div>
-<div class="sect3">
-<h4 id="cli-output-argument_cli-guide">A.1.2. Specifying the output directory</h4>
-<div class="paragraph">
-<p>Specify the path to the directory to output the report information generated by APPCAT.</p>
-</div>
-<div class="listingblock">
-<div class="title">Usage</div>
-<div class="content">
-<pre class="highlight nowrap"><code>--output &lt;OUTPUT_REPORT_DIRECTORY&gt;</code></pre>
-</div>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>If omitted, the report will be generated in an <code>&lt;INPUT_ARCHIVE_OR_DIRECTORY&gt;.report</code> directory.</p>
-</li>
-<li>
-<p>If the output directory exists, you will be prompted with the following (with a default of N).</p>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code>Overwrite all contents of "/home/username/&lt;OUTPUT_REPORT_DIRECTORY&gt;" (anything already in the directory will be deleted)? [y,N]</code></pre>
-</div>
-</div>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>However, if you specify the <code>--overwrite</code> argument, APPCAT will proceed to delete and recreate the directory. See the description of this argument for more information.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="cli-source-argument_cli-guide">A.1.3. Setting the source technology</h4>
-<div class="paragraph">
-<p>A space-delimited list of one or more source technologies, servers, platforms, or frameworks to migrate from. This argument, in conjunction with the <code>--target</code> argument, helps to determine which rulesets are used. Use the <code>--listSourceTechnologies</code> argument to list all available sources.</p>
-</div>
-<div class="listingblock">
-<div class="title">Usage</div>
-<div class="content">
-<pre class="highlight nowrap"><code>--source &lt;SOURCE_1&gt; &lt;SOURCE_2&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>--source</code> argument now provides version support, which follows the <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">Maven version range syntax</a>. This instructs APPCAT to only run the rulesets matching the specified versions. For example, <code>--source eap:5</code>.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="cli-target-argument_cli-guide">A.1.4. Setting the target technology</h4>
-<div class="paragraph">
-<p>A space-delimited list of one or more target technologies, servers, platforms, or frameworks to migrate to. This argument, in conjunction with the <code>--source</code> argument, helps to determine which rulesets are used. If you do not specify this option, you are prompted to select a target. Use the <code>--listTargetTechnologies</code> argument to list all available targets.</p>
-</div>
-<div class="listingblock">
-<div class="title">Usage</div>
-<div class="content">
-<pre class="highlight nowrap"><code>--target &lt;TARGET_1&gt; &lt;TARGET_2&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>--target</code> argument now provides version support, which follows the <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">Maven version range syntax</a>. This instructs APPCAT to only run the rulesets matching the specified versions. For example, <code>--target eap:7</code>.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="cli-packages-argument_cli-guide">A.1.5. Selecting packages</h4>
-<div class="paragraph">
-<p>A space-delimited list of the packages to be evaluated by APPCAT. It is highly recommended to use this argument.</p>
-</div>
-<div class="listingblock">
-<div class="title">Usage</div>
-<div class="content">
-<pre class="highlight nowrap"><code>--packages &lt;PACKAGE_1&gt; &lt;PACKAGE_2&gt; &lt;PACKAGE_N&gt;</code></pre>
-</div>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>In most cases, you are interested only in evaluating custom application class packages and not standard Java EE or third party packages. The <code>&lt;PACKAGE_N&gt;</code> argument is a package prefix; all subpackages will be scanned. For example, to scan the packages <code>com.mycustomapp</code> and <code>com.myotherapp</code>, use <code>--packages com.mycustomapp com.myotherapp</code> argument on the command line.</p>
-</li>
-<li>
-<p>While you can provide package names for standard Java EE third party software like <code>org.apache</code>, it is usually best not to include them as they should not impact the migration effort.</p>
-</li>
-</ul>
-</div>
-<div class="admonitionblock warning">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Warning</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>If you omit the <code>--packages</code> argument, every package in the application is scanned, which can impact performance.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="tech-tags_cli-guide">A.2. Supported technology tags</h3>
-<div class="paragraph">
-<p>The following technology tags are supported in APPCAT 6.3.0:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>0MQ Client</p>
-</li>
-<li>
-<p>3scale</p>
-</li>
-<li>
-<p>Acegi Security</p>
-</li>
-<li>
-<p>AcrIS Security</p>
-</li>
-<li>
-<p>ActiveMQ library</p>
-</li>
-<li>
-<p>Airframe</p>
-</li>
-<li>
-<p>Airlift Log Manager</p>
-</li>
-<li>
-<p>AKKA JTA</p>
-</li>
-<li>
-<p>Akka Testkit</p>
-</li>
-<li>
-<p>Amazon SQS Client</p>
-</li>
-<li>
-<p>AMQP Client</p>
-</li>
-<li>
-<p>Anakia</p>
-</li>
-<li>
-<p>AngularFaces</p>
-</li>
-<li>
-<p>ANTLR StringTemplate</p>
-</li>
-<li>
-<p>AOP Alliance</p>
-</li>
-<li>
-<p>Apache Accumulo Client</p>
-</li>
-<li>
-<p>Apache Aries</p>
-</li>
-<li>
-<p>Apache Commons JCS</p>
-</li>
-<li>
-<p>Apache Commons Validator</p>
-</li>
-<li>
-<p>Apache Flume</p>
-</li>
-<li>
-<p>Apache Geronimo</p>
-</li>
-<li>
-<p>Apache Hadoop</p>
-</li>
-<li>
-<p>Apache HBase Client</p>
-</li>
-<li>
-<p>Apache Ignite</p>
-</li>
-<li>
-<p>Apache Karaf</p>
-</li>
-<li>
-<p>Apache Mahout</p>
-</li>
-<li>
-<p>Apache Meecrowave JTA</p>
-</li>
-<li>
-<p>Apache Sirona JTA</p>
-</li>
-<li>
-<p>Apache Synapse</p>
-</li>
-<li>
-<p>Apache Tapestry</p>
-</li>
-<li>
-<p>Apiman</p>
-</li>
-<li>
-<p>Applet</p>
-</li>
-<li>
-<p>Arquillian</p>
-</li>
-<li>
-<p>AspectJ</p>
-</li>
-<li>
-<p>Atomikos JTA</p>
-</li>
-<li>
-<p>Avalon Logkit</p>
-</li>
-<li>
-<p>Axion Driver</p>
-</li>
-<li>
-<p>Axis</p>
-</li>
-<li>
-<p>Axis2</p>
-</li>
-<li>
-<p>BabbageFaces</p>
-</li>
-<li>
-<p>Bean Validation</p>
-</li>
-<li>
-<p>BeanInject</p>
-</li>
-<li>
-<p>Blaze</p>
-</li>
-<li>
-<p>Blitz4j</p>
-</li>
-<li>
-<p>BootsFaces</p>
-</li>
-<li>
-<p>Bouncy Castle</p>
-</li>
-<li>
-<p>ButterFaces</p>
-</li>
-<li>
-<p>Cache API</p>
-</li>
-<li>
-<p>Cactus</p>
-</li>
-<li>
-<p>Camel</p>
-</li>
-<li>
-<p>Camel Messaging Client</p>
-</li>
-<li>
-<p>Camunda</p>
-</li>
-<li>
-<p>Cassandra Client</p>
-</li>
-<li>
-<p>CDI</p>
-</li>
-<li>
-<p>Cfg Engine</p>
-</li>
-<li>
-<p>Chunk Templates</p>
-</li>
-<li>
-<p>Cloudera</p>
-</li>
-<li>
-<p>Coherence</p>
-</li>
-<li>
-<p>Common Annotations</p>
-</li>
-<li>
-<p>Composite Logging</p>
-</li>
-<li>
-<p>Composite Logging JCL</p>
-</li>
-<li>
-<p>Concordion</p>
-</li>
-<li>
-<p>CSS</p>
-</li>
-<li>
-<p>Cucumber</p>
-</li>
-<li>
-<p>Dagger</p>
-</li>
-<li>
-<p>DbUnit</p>
-</li>
-<li>
-<p>Demoiselle JTA</p>
-</li>
-<li>
-<p>Derby Driver</p>
-</li>
-<li>
-<p>Drools</p>
-</li>
-<li>
-<p>DVSL</p>
-</li>
-<li>
-<p>Dynacache</p>
-</li>
-<li>
-<p>EAR Deployment</p>
-</li>
-<li>
-<p>Easy Rules</p>
-</li>
-<li>
-<p>EasyMock</p>
-</li>
-<li>
-<p>Eclipse RCP</p>
-</li>
-<li>
-<p>EclipseLink</p>
-</li>
-<li>
-<p>Ehcache</p>
-</li>
-<li>
-<p>EJB</p>
-</li>
-<li>
-<p>EJB XML</p>
-</li>
-<li>
-<p>Elasticsearch</p>
-</li>
-<li>
-<p>Entity Bean</p>
-</li>
-<li>
-<p>EtlUnit</p>
-</li>
-<li>
-<p>Eureka</p>
-</li>
-<li>
-<p>Everit JTA</p>
-</li>
-<li>
-<p>Evo JTA</p>
-</li>
-<li>
-<p>Feign</p>
-</li>
-<li>
-<p>File system Logging</p>
-</li>
-<li>
-<p>FormLayoutMaker</p>
-</li>
-<li>
-<p>FreeMarker</p>
-</li>
-<li>
-<p>Geronimo JTA</p>
-</li>
-<li>
-<p>GFC Logging</p>
-</li>
-<li>
-<p>GIN</p>
-</li>
-<li>
-<p>GlassFish JTA</p>
-</li>
-<li>
-<p>Google Guice</p>
-</li>
-<li>
-<p>Grails</p>
-</li>
-<li>
-<p>Grapht DI</p>
-</li>
-<li>
-<p>Guava Testing</p>
-</li>
-<li>
-<p>GWT</p>
-</li>
-<li>
-<p>H2 Driver</p>
-</li>
-<li>
-<p>Hamcrest</p>
-</li>
-<li>
-<p>Handlebars</p>
-</li>
-<li>
-<p>HavaRunner</p>
-</li>
-<li>
-<p>Hazelcast</p>
-</li>
-<li>
-<p>Hdiv</p>
-</li>
-<li>
-<p>Hibernate</p>
-</li>
-<li>
-<p>Hibernate Cfg</p>
-</li>
-<li>
-<p>Hibernate Mapping</p>
-</li>
-<li>
-<p>Hibernate OGM</p>
-</li>
-<li>
-<p>HighFaces</p>
-</li>
-<li>
-<p>HornetQ Client</p>
-</li>
-<li>
-<p>HSQLDB Driver</p>
-</li>
-<li>
-<p>HTTP Client</p>
-</li>
-<li>
-<p>HttpUnit</p>
-</li>
-<li>
-<p>ICEfaces</p>
-</li>
-<li>
-<p>Ickenham</p>
-</li>
-<li>
-<p>Ignite JTA</p>
-</li>
-<li>
-<p>Ikasan</p>
-</li>
-<li>
-<p>iLog</p>
-</li>
-<li>
-<p>Infinispan</p>
-</li>
-<li>
-<p>Injekt for Kotlin</p>
-</li>
-<li>
-<p>Iroh</p>
-</li>
-<li>
-<p>Istio</p>
-</li>
-<li>
-<p>Jamon</p>
-</li>
-<li>
-<p>Jasypt</p>
-</li>
-<li>
-<p>Java EE Batch</p>
-</li>
-<li>
-<p>Java EE Batch API</p>
-</li>
-<li>
-<p>Java EE JACC</p>
-</li>
-<li>
-<p>Java EE JAXB</p>
-</li>
-<li>
-<p>Java EE JAXR</p>
-</li>
-<li>
-<p>Java EE JSON-P</p>
-</li>
-<li>
-<p>Java Transaction API</p>
-</li>
-<li>
-<p>JavaFX</p>
-</li>
-<li>
-<p>JavaScript</p>
-</li>
-<li>
-<p>Javax Inject</p>
-</li>
-<li>
-<p>JAX-RS</p>
-</li>
-<li>
-<p>JAX-WS</p>
-</li>
-<li>
-<p>JayWire</p>
-</li>
-<li>
-<p>JBehave</p>
-</li>
-<li>
-<p>JBoss Cache</p>
-</li>
-<li>
-<p>JBoss EJB XML</p>
-</li>
-<li>
-<p>JBoss logging</p>
-</li>
-<li>
-<p>JBoss Transactions</p>
-</li>
-<li>
-<p>JBoss Web XML</p>
-</li>
-<li>
-<p>JBossMQ Client</p>
-</li>
-<li>
-<p>JBPM</p>
-</li>
-<li>
-<p>JCA</p>
-</li>
-<li>
-<p>Jcabi Log</p>
-</li>
-<li>
-<p>JCache</p>
-</li>
-<li>
-<p>JCunit</p>
-</li>
-<li>
-<p>JDBC</p>
-</li>
-<li>
-<p>JDBC datasources</p>
-</li>
-<li>
-<p>JDBC XA datasources</p>
-</li>
-<li>
-<p>Jersey</p>
-</li>
-<li>
-<p>Jetbrick Template</p>
-</li>
-<li>
-<p>Jetty</p>
-</li>
-<li>
-<p>JFreeChart</p>
-</li>
-<li>
-<p>JFunk</p>
-</li>
-<li>
-<p>JGoodies</p>
-</li>
-<li>
-<p>JMock</p>
-</li>
-<li>
-<p>JMockit</p>
-</li>
-<li>
-<p>JMS Connection Factory</p>
-</li>
-<li>
-<p>JMS Queue</p>
-</li>
-<li>
-<p>JMS Topic</p>
-</li>
-<li>
-<p>JMustache</p>
-</li>
-<li>
-<p>JNA</p>
-</li>
-<li>
-<p>JNI</p>
-</li>
-<li>
-<p>JNLP</p>
-</li>
-<li>
-<p>JPA entities</p>
-</li>
-<li>
-<p>JPA Matchers</p>
-</li>
-<li>
-<p>JPA named queries</p>
-</li>
-<li>
-<p>JPA XML</p>
-</li>
-<li>
-<p>JSecurity</p>
-</li>
-<li>
-<p>JSF</p>
-</li>
-<li>
-<p>JSF Page</p>
-</li>
-<li>
-<p>JSilver</p>
-</li>
-<li>
-<p>JSON-B</p>
-</li>
-<li>
-<p>JSP Page</p>
-</li>
-<li>
-<p>JSTL</p>
-</li>
-<li>
-<p>JTA</p>
-</li>
-<li>
-<p>Jukito</p>
-</li>
-<li>
-<p>JUnit</p>
-</li>
-<li>
-<p>Ka DI</p>
-</li>
-<li>
-<p>Keyczar</p>
-</li>
-<li>
-<p>Kibana</p>
-</li>
-<li>
-<p>KLogger</p>
-</li>
-<li>
-<p>Kodein</p>
-</li>
-<li>
-<p>Kotlin Logging</p>
-</li>
-<li>
-<p>KouInject</p>
-</li>
-<li>
-<p>KumuluzEE JTA</p>
-</li>
-<li>
-<p>LevelDB Client</p>
-</li>
-<li>
-<p>Liferay</p>
-</li>
-<li>
-<p>LiferayFaces</p>
-</li>
-<li>
-<p>Lift JTA</p>
-</li>
-<li>
-<p>Log.io</p>
-</li>
-<li>
-<p>Log4J</p>
-</li>
-<li>
-<p>Log4s</p>
-</li>
-<li>
-<p>Logback</p>
-</li>
-<li>
-<p>Logging Utils</p>
-</li>
-<li>
-<p>Logstash</p>
-</li>
-<li>
-<p>Lumberjack</p>
-</li>
-<li>
-<p>Macros</p>
-</li>
-<li>
-<p>Magicgrouplayout</p>
-</li>
-<li>
-<p>Mail</p>
-</li>
-<li>
-<p>Management EJB</p>
-</li>
-<li>
-<p>MapR</p>
-</li>
-<li>
-<p>MckoiSQLDB Driver</p>
-</li>
-<li>
-<p>Memcached</p>
-</li>
-<li>
-<p>Message (MDB)</p>
-</li>
-<li>
-<p>Micro DI</p>
-</li>
-<li>
-<p>Micrometer</p>
-</li>
-<li>
-<p>Microsoft SQL Driver</p>
-</li>
-<li>
-<p>MiGLayout</p>
-</li>
-<li>
-<p>MinLog</p>
-</li>
-<li>
-<p>Mixer</p>
-</li>
-<li>
-<p>Mockito</p>
-</li>
-<li>
-<p>MongoDB Client</p>
-</li>
-<li>
-<p>Monolog</p>
-</li>
-<li>
-<p>Morphia</p>
-</li>
-<li>
-<p>MRules</p>
-</li>
-<li>
-<p>Mule</p>
-</li>
-<li>
-<p>Mule Functional Test Framework</p>
-</li>
-<li>
-<p>MultithreadedTC</p>
-</li>
-<li>
-<p>Mycontainer JTA</p>
-</li>
-<li>
-<p>MyFaces</p>
-</li>
-<li>
-<p>MySQL Driver</p>
-</li>
-<li>
-<p>Narayana Arjuna</p>
-</li>
-<li>
-<p>Needle</p>
-</li>
-<li>
-<p>Neo4j</p>
-</li>
-<li>
-<p>NLOG4J</p>
-</li>
-<li>
-<p>Nuxeo JTA/JCA</p>
-</li>
-<li>
-<p>OACC</p>
-</li>
-<li>
-<p>OAUTH</p>
-</li>
-<li>
-<p>OCPsoft Logging Utils</p>
-</li>
-<li>
-<p>OmniFaces</p>
-</li>
-<li>
-<p>OpenFaces</p>
-</li>
-<li>
-<p>OpenPojo</p>
-</li>
-<li>
-<p>OpenSAML</p>
-</li>
-<li>
-<p>OpenWS</p>
-</li>
-<li>
-<p>OPS4J Pax Logging Service</p>
-</li>
-<li>
-<p>Oracle ADF</p>
-</li>
-<li>
-<p>Oracle DB Driver</p>
-</li>
-<li>
-<p>Oracle Forms</p>
-</li>
-<li>
-<p>Orion EJB XML</p>
-</li>
-<li>
-<p>Orion Web XML</p>
-</li>
-<li>
-<p>Oscache</p>
-</li>
-<li>
-<p>OTR4J</p>
-</li>
-<li>
-<p>OW2 JTA</p>
-</li>
-<li>
-<p>OW2 Log Util</p>
-</li>
-<li>
-<p>OWASP CSRF Guard</p>
-</li>
-<li>
-<p>OWASP ESAPI</p>
-</li>
-<li>
-<p>Peaberry</p>
-</li>
-<li>
-<p>Pega</p>
-</li>
-<li>
-<p>Persistence units</p>
-</li>
-<li>
-<p>Petals EIP</p>
-</li>
-<li>
-<p>PicketBox</p>
-</li>
-<li>
-<p>PicketLink</p>
-</li>
-<li>
-<p>PicoContainer</p>
-</li>
-<li>
-<p>Play</p>
-</li>
-<li>
-<p>Play Test</p>
-</li>
-<li>
-<p>Plexus Container</p>
-</li>
-<li>
-<p>Polyforms DI</p>
-</li>
-<li>
-<p>Portlet</p>
-</li>
-<li>
-<p>PostgreSQL Driver</p>
-</li>
-<li>
-<p>PowerMock</p>
-</li>
-<li>
-<p>PrimeFaces</p>
-</li>
-<li>
-<p>Properties</p>
-</li>
-<li>
-<p>Qpid Client</p>
-</li>
-<li>
-<p>RabbitMQ Client</p>
-</li>
-<li>
-<p>RandomizedTesting Runner</p>
-</li>
-<li>
-<p>Resource Adapter</p>
-</li>
-<li>
-<p>REST Assured</p>
-</li>
-<li>
-<p>Restito</p>
-</li>
-<li>
-<p>RichFaces</p>
-</li>
-<li>
-<p>RMI</p>
-</li>
-<li>
-<p>RocketMQ Client</p>
-</li>
-<li>
-<p>Rythm Template Engine</p>
-</li>
-<li>
-<p>SAML</p>
-</li>
-<li>
-<p>Santuario</p>
-</li>
-<li>
-<p>Scalate</p>
-</li>
-<li>
-<p>Scaldi</p>
-</li>
-<li>
-<p>Scribe</p>
-</li>
-<li>
-<p>Seam</p>
-</li>
-<li>
-<p>Security Realm</p>
-</li>
-<li>
-<p>ServiceMix</p>
-</li>
-<li>
-<p>Servlet</p>
-</li>
-<li>
-<p>ShiftOne</p>
-</li>
-<li>
-<p>Shiro</p>
-</li>
-<li>
-<p>Silk DI</p>
-</li>
-<li>
-<p>SLF4J</p>
-</li>
-<li>
-<p>Snippetory Template Engine</p>
-</li>
-<li>
-<p>SNMP4J</p>
-</li>
-<li>
-<p>Socket handler logging</p>
-</li>
-<li>
-<p>Spark</p>
-</li>
-<li>
-<p>Specsy</p>
-</li>
-<li>
-<p>Spock</p>
-</li>
-<li>
-<p>Spring</p>
-</li>
-<li>
-<p>Spring Batch</p>
-</li>
-<li>
-<p>Spring Boot</p>
-</li>
-<li>
-<p>Spring Boot Actuator</p>
-</li>
-<li>
-<p>Spring Boot Cache</p>
-</li>
-<li>
-<p>Spring Boot Flo</p>
-</li>
-<li>
-<p>Spring Cloud Config</p>
-</li>
-<li>
-<p>Spring Cloud Function</p>
-</li>
-<li>
-<p>Spring Data</p>
-</li>
-<li>
-<p>Spring Data JPA</p>
-</li>
-<li>
-<p>spring DI</p>
-</li>
-<li>
-<p>Spring Integration</p>
-</li>
-<li>
-<p>Spring JMX</p>
-</li>
-<li>
-<p>Spring Messaging Client</p>
-</li>
-<li>
-<p>Spring MVC</p>
-</li>
-<li>
-<p>Spring Properties</p>
-</li>
-<li>
-<p>Spring Scheduled</p>
-</li>
-<li>
-<p>Spring Security</p>
-</li>
-<li>
-<p>Spring Shell</p>
-</li>
-<li>
-<p>Spring Test</p>
-</li>
-<li>
-<p>Spring Transactions</p>
-</li>
-<li>
-<p>Spring Web</p>
-</li>
-<li>
-<p>SQLite Driver</p>
-</li>
-<li>
-<p>SSL</p>
-</li>
-<li>
-<p>Standard Widget Toolkit (SWT)</p>
-</li>
-<li>
-<p>Stateful (SFSB)</p>
-</li>
-<li>
-<p>Stateless (SLSB)</p>
-</li>
-<li>
-<p>Sticky Configured</p>
-</li>
-<li>
-<p>Stripes</p>
-</li>
-<li>
-<p>Struts</p>
-</li>
-<li>
-<p>SubCut</p>
-</li>
-<li>
-<p>Swagger</p>
-</li>
-<li>
-<p>SwarmCache</p>
-</li>
-<li>
-<p>Swing</p>
-</li>
-<li>
-<p>SwitchYard</p>
-</li>
-<li>
-<p>Syringe</p>
-</li>
-<li>
-<p>Talend ESB</p>
-</li>
-<li>
-<p>Teiid</p>
-</li>
-<li>
-<p>TensorFlow</p>
-</li>
-<li>
-<p>Test Interface</p>
-</li>
-<li>
-<p>TestNG</p>
-</li>
-<li>
-<p>Thymeleaf</p>
-</li>
-<li>
-<p>TieFaces</p>
-</li>
-<li>
-<p>tinylog</p>
-</li>
-<li>
-<p>Tomcat</p>
-</li>
-<li>
-<p>Tornado Inject</p>
-</li>
-<li>
-<p>Trimou</p>
-</li>
-<li>
-<p>Trunk JGuard</p>
-</li>
-<li>
-<p>Twirl</p>
-</li>
-<li>
-<p>Twitter Util Logging</p>
-</li>
-<li>
-<p>UberFire</p>
-</li>
-<li>
-<p>Unirest</p>
-</li>
-<li>
-<p>Unitils</p>
-</li>
-<li>
-<p>Vaadin</p>
-</li>
-<li>
-<p>Velocity</p>
-</li>
-<li>
-<p>Vlad</p>
-</li>
-<li>
-<p>Water Template Engine</p>
-</li>
-<li>
-<p>Web Services Metadata</p>
-</li>
-<li>
-<p>Web Session</p>
-</li>
-<li>
-<p>Web XML File</p>
-</li>
-<li>
-<p>WebLogic Web XML</p>
-</li>
-<li>
-<p>Webmacro</p>
-</li>
-<li>
-<p>WebSocket</p>
-</li>
-<li>
-<p>WebSphere EJB</p>
-</li>
-<li>
-<p>WebSphere EJB Ext</p>
-</li>
-<li>
-<p>WebSphere Web XML</p>
-</li>
-<li>
-<p>WebSphere WS Binding</p>
-</li>
-<li>
-<p>WebSphere WS Extension</p>
-</li>
-<li>
-<p>Weka</p>
-</li>
-<li>
-<p>Weld</p>
-</li>
-<li>
-<p>WF Core JTA</p>
-</li>
-<li>
-<p>Wicket</p>
-</li>
-<li>
-<p>Winter</p>
-</li>
-<li>
-<p>WSDL</p>
-</li>
-<li>
-<p>WSO2</p>
-</li>
-<li>
-<p>WSS4J</p>
-</li>
-<li>
-<p>XACML</p>
-</li>
-<li>
-<p>XFire</p>
-</li>
-<li>
-<p>XMLUnit</p>
-</li>
-<li>
-<p>Zbus Client</p>
-</li>
-<li>
-<p>Zipkin</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect2">
-<h3 id="about-story-points_cli-guide">A.3. About rule story points</h3>
-<div class="sect3">
-<h4 id="_what_are_story_points">A.3.1. What are story points?</h4>
-<div class="paragraph">
-<p><em>Story points</em> are an abstract metric commonly used in Agile software development to estimate the <em>level of effort</em> needed to implement a feature or change.</p>
-</div>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit uses story points to express the level of effort needed to migrate particular application constructs, and the application as a whole. It does not necessarily translate to man-hours, but the value should be consistent across tasks.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_how_story_points_are_estimated_in_rules">A.3.2. How story points are estimated in rules</h4>
-<div class="paragraph">
-<p>Estimating the level of effort for the story points for a rule can be tricky. The following are the general guidelines APPCAT uses when estimating the level of effort required for a rule.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 15%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Level of Effort</th>
-<th class="tableblock halign-left valign-top">Story Points</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Information</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An informational warning with very low or no priority for migration.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Trivial</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration is a trivial change or a simple library swap with no or minimal API changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Complex</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The changes required for the migration task are complex, but have a documented solution.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Redesign</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration task requires a redesign or a complete library change, with significant API changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rearchitecture</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration requires a complete rearchitecture of the component or subsystem.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unknown</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">13</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration solution is not known and may need a complete rewrite.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_task_category">A.3.3. Task category</h4>
-<div class="paragraph">
-<p>In addition to the level of effort, you can categorize migration tasks to indicate the severity of the task. The following categories are used to group issues to help prioritize the migration effort.</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">Mandatory</dt>
-<dd>
-<p>The task must be completed for a successful migration. If the changes are not made, the resulting application will not build or run successfully. Examples include replacement of proprietary APIs that are not supported in the target platform.</p>
-</dd>
-<dt class="hdlist1">Optional</dt>
-<dd>
-<p>If the migration task is not completed, the application should work, but the results may not be optimal. If the change is not made at the time of migration, it is recommended to put it on the schedule soon after your migration is completed. An example of this would be the upgrade of EJB 2.x code to EJB 3.</p>
-</dd>
-<dt class="hdlist1">Potential</dt>
-<dd>
-<p>The task should be examined during the migration process, but there is not enough detailed information to determine if the task is mandatory for the migration to succeed. An example of this would be migrating a third-party proprietary type where there is no directly compatible type.</p>
-</dd>
-<dt class="hdlist1">Information</dt>
-<dd>
-<p>The task is included to inform you of the existence of certain files. These may need to be examined or modified as part of the modernization effort, but changes are typically not required. An example of this would be the presence of a logging dependency or a Maven <code>pom.xml</code>.</p>
-</dd>
-</dl>
-</div>
-<div class="paragraph">
-<p>For more information on categorizing tasks, see <a href="https://azure.github.io/appcat-docs/rules-development-guide/#rule_categories_rules-development-guide">Using custom rule categories</a>.</p>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_additional_resources">A.4. Additional Resources</h3>
-<div class="sect3">
-<h4 id="get-involved_cli-guide">A.4.1. Getting involved</h4>
-<div class="paragraph">
-<p>To help the Azure Application and Code Assessment Toolkit cover most application constructs and server configurations, including yours, you can help with any of the following items.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>Send an email to <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a> and let us know what APPCAT migration rules should cover.</p>
-</li>
-<li>
-<p>You can also contribute by providing feedback directly to our GitHub project at <a href="https://github.com/Azure/appcat-rulesets/issues">https://github.com/Azure/appcat-rulesets/issues</a>.</p>
-</li>
-<li>
-<p>Provide example applications to test migration rules.</p>
-</li>
-<li>
-<p>Identify application components and problem areas that may be difficult to migrate.</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Write a short description of these problem migration areas.</p>
-</li>
-<li>
-<p>Write a brief overview describing how to solve the problem migration areas.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Try Azure Application and Code Assessment Toolkit on your application. Be sure to report any issues you encounter.</p>
-</li>
-<li>
-<p>Contribute to the Azure Application and Code Assessment Toolkit rules repository.</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Write a Azure Application and Code Assessment Toolkit rule to identify or automate a migration process.</p>
-</li>
-<li>
-<p>Create a test for the new rule.</p>
-</li>
-<li>
-<p>Details are provided in the <a href="https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.1/html-single/rules_development_guide"><em>Rules Development Guide</em></a>.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Contribute to the project source code.</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Create a core rule.</p>
-</li>
-<li>
-<p>Improve APPCAT performance or efficiency.</p>
-</li>
-</ul>
-</div>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>Any level of involvement is greatly appreciated!</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="important-links_cli-guide">A.4.2. Resources</h4>
-<div class="ulist">
-<ul>
-<li>
-<p>GitHub issues: <a href="https://github.com/Azure/appcat-rulesets/issues" class="bare">https://github.com/Azure/appcat-rulesets/issues</a></p>
-</li>
-<li>
-<p>Contact the APPCAT team at: <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a></p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_reporting_issues">A.4.3. Reporting issues</h4>
-<div class="paragraph">
-<p>APPCAT uses GitHub as its issue tracking system. If you encounter an issue executing APPCAT, submit a <a href="https://github.com/Azure/appcat-rulesets/issues">an issue</a>.</p>
-</div>
-<div class="paragraph">
-<p><br>
-<br>
-<br>
-<br></p>
-</div>
-<div class="paragraph">
-<p><em class="right">Revised on 2023-08-08 02:32:15 UTC</em></p>
-</div>
-</div>
-</div>
-</div>
-</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="ignored-locations_cli-guide">5.3.3. Searching locations for exclusion</h4>
+                    <div class="paragraph">
+                        <p>APPCAT searches the following locations:</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p><code>~/.appcat/ignore/</code></p>
+                            </li>
+                            <li>
+                                <p><code>~/.windup/ignore/</code></p>
+                            </li>
+                            <li>
+                                <p><code>&lt;APPCAT_HOME&gt;/ignore/</code></p>
+                            </li>
+                            <li>
+                                <p>Any files and folders specified by the <code>--userIgnorePath</code> argument</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p>Each of these files must conform to the rules specified for excluding packages or files, depending on the type of content to be excluded.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="_reference_material">Appendix A: Reference material</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="cli-args_cli-guide">A.1. About APPCAT command-line arguments</h3>
+                <div class="paragraph">
+                    <p>The following is a detailed description of the available APPCAT command line arguments.</p>
+                </div>
+                <div class="admonitionblock note">
+                    <table>
+                        <tr>
+                            <td class="icon">
+                                <div class="title">Note</div>
+                            </td>
+                            <td class="content">
+                                <div class="paragraph">
+                                    <p>To run the APPCAT command without prompting, for example when executing from a script, you must use the following arguments:</p>
+                                </div>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p><code>--batchMode</code></p>
+                                        </li>
+                                        <li>
+                                            <p><code>--overwrite</code></p>
+                                        </li>
+                                        <li>
+                                            <p><code>--input</code></p>
+                                        </li>
+                                        <li>
+                                            <p><code>--target</code></p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <table class="tableblock frame-all grid-all stretch">
+                    <caption class="title">Table 1. APPCAT CLI arguments</caption>
+                    <colgroup>
+                        <col style="width: 40%;">
+                        <col style="width: 60%;">
+                    </colgroup>
+                    <thead>
+                    <tr>
+                        <th class="tableblock halign-left valign-top">Argument</th>
+                        <th class="tableblock halign-left valign-top">Description</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--additionalClassPath</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of additional JAR files or directories to add to the class path so that they are available for decompilation or other analysis.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--addonDir</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Add the specified directory as a custom add-on repository.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--analyzeKnownLibraries</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to analyze known software artifacts embedded within your application. By default, APPCAT only analyzes application code.</p>
+                        </div>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>This option may result in a longer execution time and a large number of migration issues being reported.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--batchMode</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to specify that APPCAT should be run in a non-interactive mode without prompting for confirmation. This mode takes the default values for any parameters not passed in to the command line.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--debug</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to run APPCAT in debug mode.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--disableTattletale</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to disable generation of the Tattletale report. If both <code>enableTattletale</code> and <code>disableTattletale</code> are set to true, then <code>disableTattletale</code> will be ignored and the Tattletale report will still be generated.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--discoverPackages</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to list all available packages in the input binary application.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--enableClassNotFoundAnalysis</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to enable analysis of Java files that are not available on the class path. This should not be used if some classes will be unavailable at analysis time.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--enableCompatibleFilesReport</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to enable generation of the Compatible Files report. Due to processing all files without found issues, this report may take a long time for large applications.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--enableTattletale</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to enable generation of a Tattletale report for each application. This option is enabled by default when <code>eap</code> is in the included target. If both <code>enableTattletale</code> and <code>disableTattletale</code> are set to true, then <code>disableTattletale</code> will be ignored and the Tattletale report will still be generated.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--enableTransactionAnalysis</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>[Technology Preview] Flag to enable generation of a Transactions report that displays the call stack, which executes operations on relational database tables. The Enable Transaction Analysis feature supports Spring Data JPA and the traditional <code>preparedStatement()</code> method for SQL statement execution. It does not support ORM frameworks, such as Hibernate.</p>
+                        </div>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>enableTransactionAnalysis is a Technology Preview feature only. Technology Preview features are not supported with any service level agreements (SLAs) and might not be functionally complete. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--excludePackages</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of packages to exclude from evaluation. For example, entering <code>com.mycompany.commonutilities</code> excludes all classes whose package names begin with <code>com.mycompany.commonutilities</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--excludeTags</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of tags to exclude. When specified, rules with these tags will not be processed. To see the full list of tags, use the <code>--listTags</code> argument.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--explodedApp</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to indicate that the provided input directory contains source files for a single application.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--exportCSV</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to export the report data to a CSV file on your local file system. APPCAT creates the file in the directory specified by the <code>--output</code> argument. The CSV file can be imported into a spreadsheet program for data manipulation and analysis.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--exportSummary</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to instruct APPCAT to generate an <code>analysisSummary.json</code> export file in the output directory. The file contains analysis summary information for each application analyzed, including the number of incidents and story points by category, and all of the technology tags associated with the analyzed applications.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--exportZipReport</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>This argument creates a <code>reports.zip</code> file in the output folder. The file contains the analysis output, typically, the reports. If requested, it can also contain the CSV export files.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--help</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Display the APPCAT help message.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--immutableAddonDir</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Add the specified directory as a custom read-only add-on repository.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--includeTags</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of tags to use. When specified, only rules with these tags will be processed. To see the full list of tags, use the <code>--listTags</code> argument.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--input</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of the path to the file or directory containing one or more applications to be analyzed. This argument is required.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--install</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Specify add-ons to install. The syntax is <code>&lt;GROUP_ID&gt;:&lt;ARTIFACT_ID&gt;[:&lt;VERSION&gt;]</code>. For example, <code>--install core-addon-x</code> or <code>--install org.example.addon:example:1.0.0</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--keepWorkDirs</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to instruct APPCAT to not delete temporary working files, such as the graph database and extracted archive files. This is useful for debugging purposes.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--legacyReports</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to instruct APPCAT to generate the old format reports instead of the new format reports.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--list</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to list installed add-ons.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--listSourceTechnologies</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to list all available source technologies.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--listTags</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to list all available tags.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--listTargetTechnologies</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to list all available target technologies.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--mavenize</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to create a Maven project directory structure based on the structure and content of the application. This creates <code>pom.xml</code> files using the appropriate Java EE API and the correct dependencies between project modules. See also the <code>--mavenizeGroupId</code> option.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--mavenizeGroupId</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>When used with the <code>--mavenize</code> option, all generated <code>pom.xml</code> files will use the provided value for their <code>&lt;groupId&gt;</code>. If this argument is omitted, APPCAT will attempt to determine an appropriate <code>&lt;groupId&gt;</code> based on the application, or will default to <code>com.mycompany.mavenized</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--online</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to allow network access for features that require it. Currently only validating XML schemas against external resources relies on Internet access. Note that this comes with a performance penalty.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--output</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Specify the path to the directory to output the report information generated by APPCAT.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--overwrite</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to force delete the existing output directory specified by <code>--output</code>. If you do not specify this argument and the <code>--output</code> directory exists, you are prompted to choose whether to overwrite the contents.</p>
+                        </div>
+                            <div class="admonitionblock important">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Important</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>Do not overwrite a report output directory that contains important information.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--packages</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of the packages to be evaluated by APPCAT. It is highly recommended to use this argument.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--remove</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Remove the specified add-ons. The syntax is <code>&lt;GROUP_ID&gt;:&lt;ARTIFACT_ID&gt;[:&lt;VERSION&gt;]</code>. For example, <code>--remove core-addon-x</code> or <code>--remove org.example.addon:example:1.0.0</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--skipReports</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to indicate that HTML reports should not be generated. A common use of this argument is when exporting report data to a CSV file using <code>--exportCSV</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--source</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of one or more source technologies, servers, platforms, or frameworks to migrate from. This argument, in conjunction with the <code>--target</code> argument, helps to determine which rulesets are used. Use the <code>--listSourceTechnologies</code> argument to list all available sources.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--sourceMode</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Flag to indicate that the application to be evaluated contains source files rather than compiled binaries. The sourceMode argument has been deprecated. There is no longer the need to specify it. APPCAT can intuitively process any inputs that are presented to it.  In addition, project source folders can be analyzed with binary inputs within the same analysis execution.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--target</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>A space-delimited list of one or more target technologies, servers, platforms, or frameworks to migrate to. This argument, in conjunction with the <code>--source</code> argument, helps to determine which rulesets are used. Use the <code>--listTargetTechnologies</code> argument to list all available targets.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--userIgnorePath</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Specify a location, in addition to <code>${user.home}/.appcat/ignore/</code>, for APPCAT to identify files that should be ignored.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--userLabelsDirectory</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Specify a location for APPCAT to look for custom Target Runtime Labels. The value can be a directory containing label files or a single label file. The Target Runtime Label files must use the <code>.windup.label.xml</code> suffix. The shipped Target Runtime Labels are defined within <code>$APPCAT_HOME/rules/migration-core/core.windup.label.xml</code>.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--userRulesDirectory</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Specify a location, in addition to <code>&lt;APPCAT_HOME&gt;/rules/</code> and <code>${user.home}/.appcat/rules/</code>, for APPCAT to look for custom APPCAT rules. The value can be a directory containing ruleset files or a single ruleset file. The ruleset files must use the <code>.windup.xml</code> suffix.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--version</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>Display the APPCAT version.</p>
+                        </div></div></td>
+                    </tr>
+                    <tr>
+                        <td class="tableblock halign-left valign-top"><p class="tableblock">--skipSourceCodeReports</p></td>
+                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                            <p>This option skips generating a <em>Source code report</em> when generating the application analysis report. Use this advanced option when concerned about source code information appearing in the application analysis.</p>
+                        </div></div></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <div class="sect3">
+                    <h4 id="cli-input-argument_cli-guide">A.1.1. Specifying the input</h4>
+                    <div class="paragraph">
+                        <p>A space-delimited list of the path to the file or directory containing one or more applications to be analyzed. This argument is required.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title">Usage</div>
+                        <div class="content">
+                            <pre class="highlight nowrap"><code>--input &lt;INPUT_ARCHIVE_OR_DIRECTORY&gt; [...]</code></pre>
+                        </div>
+                    </div>
+                    <div id="cli-input-file-type-arguments_cli-guide" class="paragraph">
+                        <p>Depending on whether the input file type provided to the <code>--input</code> argument is a file or directory, it will be evaluated as follows depending on the additional arguments provided.</p>
+                    </div>
+                    <div class="dlist">
+                        <dl>
+                            <dt class="hdlist1">Directory</dt>
+                            <dd>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 33.3333%;">
+                                        <col style="width: 33.3333%;">
+                                        <col style="width: 33.3334%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">--explodedApp</th>
+                                        <th class="tableblock halign-left valign-top">--sourceMode</th>
+                                        <th class="tableblock halign-left valign-top">Neither Argument</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The directory is evaluated as a single application.</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The directory is evaluated as a single application.</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Each subdirectory is evaluated as an application.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </dd>
+                            <dt class="hdlist1">File</dt>
+                            <dd>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 33.3333%;">
+                                        <col style="width: 33.3333%;">
+                                        <col style="width: 33.3334%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">--explodedApp</th>
+                                        <th class="tableblock halign-left valign-top">--sourceMode</th>
+                                        <th class="tableblock halign-left valign-top">Neither Argument</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Argument is ignored; the file is evaluated as a single application.</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The file is evaluated as a compressed project.</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The file is evaluated as a single application.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </dd>
+                        </dl>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="cli-output-argument_cli-guide">A.1.2. Specifying the output directory</h4>
+                    <div class="paragraph">
+                        <p>Specify the path to the directory to output the report information generated by APPCAT.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title">Usage</div>
+                        <div class="content">
+                            <pre class="highlight nowrap"><code>--output &lt;OUTPUT_REPORT_DIRECTORY&gt;</code></pre>
+                        </div>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>If omitted, the report will be generated in an <code>&lt;INPUT_ARCHIVE_OR_DIRECTORY&gt;.report</code> directory.</p>
+                            </li>
+                            <li>
+                                <p>If the output directory exists, you will be prompted with the following (with a default of N).</p>
+                                <div class="listingblock">
+                                    <div class="content">
+                                        <pre class="highlight nowrap"><code>Overwrite all contents of "/home/username/&lt;OUTPUT_REPORT_DIRECTORY&gt;" (anything already in the directory will be deleted)? [y,N]</code></pre>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p>However, if you specify the <code>--overwrite</code> argument, APPCAT will proceed to delete and recreate the directory. See the description of this argument for more information.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="cli-source-argument_cli-guide">A.1.3. Setting the source technology</h4>
+                    <div class="paragraph">
+                        <p>A space-delimited list of one or more source technologies, servers, platforms, or frameworks to migrate from. This argument, in conjunction with the <code>--target</code> argument, helps to determine which rulesets are used. Use the <code>--listSourceTechnologies</code> argument to list all available sources.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title">Usage</div>
+                        <div class="content">
+                            <pre class="highlight nowrap"><code>--source &lt;SOURCE_1&gt; &lt;SOURCE_2&gt;</code></pre>
+                        </div>
+                    </div>
+                    <div class="paragraph">
+                        <p>The <code>--source</code> argument now provides version support, which follows the <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">Maven version range syntax</a>. This instructs APPCAT to only run the rulesets matching the specified versions. For example, <code>--source eap:5</code>.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="cli-target-argument_cli-guide">A.1.4. Setting the target technology</h4>
+                    <div class="paragraph">
+                        <p>A space-delimited list of one or more target technologies, servers, platforms, or frameworks to migrate to. This argument, in conjunction with the <code>--source</code> argument, helps to determine which rulesets are used. If you do not specify this option, you are prompted to select a target. Use the <code>--listTargetTechnologies</code> argument to list all available targets.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title">Usage</div>
+                        <div class="content">
+                            <pre class="highlight nowrap"><code>--target &lt;TARGET_1&gt; &lt;TARGET_2&gt;</code></pre>
+                        </div>
+                    </div>
+                    <div class="paragraph">
+                        <p>The <code>--target</code> argument now provides version support, which follows the <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">Maven version range syntax</a>. This instructs APPCAT to only run the rulesets matching the specified versions. For example, <code>--target eap:7</code>.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="cli-packages-argument_cli-guide">A.1.5. Selecting packages</h4>
+                    <div class="paragraph">
+                        <p>A space-delimited list of the packages to be evaluated by APPCAT. It is highly recommended to use this argument.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title">Usage</div>
+                        <div class="content">
+                            <pre class="highlight nowrap"><code>--packages &lt;PACKAGE_1&gt; &lt;PACKAGE_2&gt; &lt;PACKAGE_N&gt;</code></pre>
+                        </div>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>In most cases, you are interested only in evaluating custom application class packages and not standard Java EE or third party packages. The <code>&lt;PACKAGE_N&gt;</code> argument is a package prefix; all subpackages will be scanned. For example, to scan the packages <code>com.mycustomapp</code> and <code>com.myotherapp</code>, use <code>--packages com.mycustomapp com.myotherapp</code> argument on the command line.</p>
+                            </li>
+                            <li>
+                                <p>While you can provide package names for standard Java EE third party software like <code>org.apache</code>, it is usually best not to include them as they should not impact the migration effort.</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="admonitionblock warning">
+                        <table>
+                            <tr>
+                                <td class="icon">
+                                    <div class="title">Warning</div>
+                                </td>
+                                <td class="content">
+                                    <div class="paragraph">
+                                        <p>If you omit the <code>--packages</code> argument, every package in the application is scanned, which can impact performance.</p>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="tech-tags_cli-guide">A.2. Supported technology tags</h3>
+                <div class="paragraph">
+                    <p>The following technology tags are supported in APPCAT 6.3.0:</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>0MQ Client</p>
+                        </li>
+                        <li>
+                            <p>3scale</p>
+                        </li>
+                        <li>
+                            <p>Acegi Security</p>
+                        </li>
+                        <li>
+                            <p>AcrIS Security</p>
+                        </li>
+                        <li>
+                            <p>ActiveMQ library</p>
+                        </li>
+                        <li>
+                            <p>Airframe</p>
+                        </li>
+                        <li>
+                            <p>Airlift Log Manager</p>
+                        </li>
+                        <li>
+                            <p>AKKA JTA</p>
+                        </li>
+                        <li>
+                            <p>Akka Testkit</p>
+                        </li>
+                        <li>
+                            <p>Amazon SQS Client</p>
+                        </li>
+                        <li>
+                            <p>AMQP Client</p>
+                        </li>
+                        <li>
+                            <p>Anakia</p>
+                        </li>
+                        <li>
+                            <p>AngularFaces</p>
+                        </li>
+                        <li>
+                            <p>ANTLR StringTemplate</p>
+                        </li>
+                        <li>
+                            <p>AOP Alliance</p>
+                        </li>
+                        <li>
+                            <p>Apache Accumulo Client</p>
+                        </li>
+                        <li>
+                            <p>Apache Aries</p>
+                        </li>
+                        <li>
+                            <p>Apache Commons JCS</p>
+                        </li>
+                        <li>
+                            <p>Apache Commons Validator</p>
+                        </li>
+                        <li>
+                            <p>Apache Flume</p>
+                        </li>
+                        <li>
+                            <p>Apache Geronimo</p>
+                        </li>
+                        <li>
+                            <p>Apache Hadoop</p>
+                        </li>
+                        <li>
+                            <p>Apache HBase Client</p>
+                        </li>
+                        <li>
+                            <p>Apache Ignite</p>
+                        </li>
+                        <li>
+                            <p>Apache Karaf</p>
+                        </li>
+                        <li>
+                            <p>Apache Mahout</p>
+                        </li>
+                        <li>
+                            <p>Apache Meecrowave JTA</p>
+                        </li>
+                        <li>
+                            <p>Apache Sirona JTA</p>
+                        </li>
+                        <li>
+                            <p>Apache Synapse</p>
+                        </li>
+                        <li>
+                            <p>Apache Tapestry</p>
+                        </li>
+                        <li>
+                            <p>Apiman</p>
+                        </li>
+                        <li>
+                            <p>Applet</p>
+                        </li>
+                        <li>
+                            <p>Arquillian</p>
+                        </li>
+                        <li>
+                            <p>AspectJ</p>
+                        </li>
+                        <li>
+                            <p>Atomikos JTA</p>
+                        </li>
+                        <li>
+                            <p>Avalon Logkit</p>
+                        </li>
+                        <li>
+                            <p>Axion Driver</p>
+                        </li>
+                        <li>
+                            <p>Axis</p>
+                        </li>
+                        <li>
+                            <p>Axis2</p>
+                        </li>
+                        <li>
+                            <p>BabbageFaces</p>
+                        </li>
+                        <li>
+                            <p>Bean Validation</p>
+                        </li>
+                        <li>
+                            <p>BeanInject</p>
+                        </li>
+                        <li>
+                            <p>Blaze</p>
+                        </li>
+                        <li>
+                            <p>Blitz4j</p>
+                        </li>
+                        <li>
+                            <p>BootsFaces</p>
+                        </li>
+                        <li>
+                            <p>Bouncy Castle</p>
+                        </li>
+                        <li>
+                            <p>ButterFaces</p>
+                        </li>
+                        <li>
+                            <p>Cache API</p>
+                        </li>
+                        <li>
+                            <p>Cactus</p>
+                        </li>
+                        <li>
+                            <p>Camel</p>
+                        </li>
+                        <li>
+                            <p>Camel Messaging Client</p>
+                        </li>
+                        <li>
+                            <p>Camunda</p>
+                        </li>
+                        <li>
+                            <p>Cassandra Client</p>
+                        </li>
+                        <li>
+                            <p>CDI</p>
+                        </li>
+                        <li>
+                            <p>Cfg Engine</p>
+                        </li>
+                        <li>
+                            <p>Chunk Templates</p>
+                        </li>
+                        <li>
+                            <p>Cloudera</p>
+                        </li>
+                        <li>
+                            <p>Coherence</p>
+                        </li>
+                        <li>
+                            <p>Common Annotations</p>
+                        </li>
+                        <li>
+                            <p>Composite Logging</p>
+                        </li>
+                        <li>
+                            <p>Composite Logging JCL</p>
+                        </li>
+                        <li>
+                            <p>Concordion</p>
+                        </li>
+                        <li>
+                            <p>CSS</p>
+                        </li>
+                        <li>
+                            <p>Cucumber</p>
+                        </li>
+                        <li>
+                            <p>Dagger</p>
+                        </li>
+                        <li>
+                            <p>DbUnit</p>
+                        </li>
+                        <li>
+                            <p>Demoiselle JTA</p>
+                        </li>
+                        <li>
+                            <p>Derby Driver</p>
+                        </li>
+                        <li>
+                            <p>Drools</p>
+                        </li>
+                        <li>
+                            <p>DVSL</p>
+                        </li>
+                        <li>
+                            <p>Dynacache</p>
+                        </li>
+                        <li>
+                            <p>EAR Deployment</p>
+                        </li>
+                        <li>
+                            <p>Easy Rules</p>
+                        </li>
+                        <li>
+                            <p>EasyMock</p>
+                        </li>
+                        <li>
+                            <p>Eclipse RCP</p>
+                        </li>
+                        <li>
+                            <p>EclipseLink</p>
+                        </li>
+                        <li>
+                            <p>Ehcache</p>
+                        </li>
+                        <li>
+                            <p>EJB</p>
+                        </li>
+                        <li>
+                            <p>EJB XML</p>
+                        </li>
+                        <li>
+                            <p>Elasticsearch</p>
+                        </li>
+                        <li>
+                            <p>Entity Bean</p>
+                        </li>
+                        <li>
+                            <p>EtlUnit</p>
+                        </li>
+                        <li>
+                            <p>Eureka</p>
+                        </li>
+                        <li>
+                            <p>Everit JTA</p>
+                        </li>
+                        <li>
+                            <p>Evo JTA</p>
+                        </li>
+                        <li>
+                            <p>Feign</p>
+                        </li>
+                        <li>
+                            <p>File system Logging</p>
+                        </li>
+                        <li>
+                            <p>FormLayoutMaker</p>
+                        </li>
+                        <li>
+                            <p>FreeMarker</p>
+                        </li>
+                        <li>
+                            <p>Geronimo JTA</p>
+                        </li>
+                        <li>
+                            <p>GFC Logging</p>
+                        </li>
+                        <li>
+                            <p>GIN</p>
+                        </li>
+                        <li>
+                            <p>GlassFish JTA</p>
+                        </li>
+                        <li>
+                            <p>Google Guice</p>
+                        </li>
+                        <li>
+                            <p>Grails</p>
+                        </li>
+                        <li>
+                            <p>Grapht DI</p>
+                        </li>
+                        <li>
+                            <p>Guava Testing</p>
+                        </li>
+                        <li>
+                            <p>GWT</p>
+                        </li>
+                        <li>
+                            <p>H2 Driver</p>
+                        </li>
+                        <li>
+                            <p>Hamcrest</p>
+                        </li>
+                        <li>
+                            <p>Handlebars</p>
+                        </li>
+                        <li>
+                            <p>HavaRunner</p>
+                        </li>
+                        <li>
+                            <p>Hazelcast</p>
+                        </li>
+                        <li>
+                            <p>Hdiv</p>
+                        </li>
+                        <li>
+                            <p>Hibernate</p>
+                        </li>
+                        <li>
+                            <p>Hibernate Cfg</p>
+                        </li>
+                        <li>
+                            <p>Hibernate Mapping</p>
+                        </li>
+                        <li>
+                            <p>Hibernate OGM</p>
+                        </li>
+                        <li>
+                            <p>HighFaces</p>
+                        </li>
+                        <li>
+                            <p>HornetQ Client</p>
+                        </li>
+                        <li>
+                            <p>HSQLDB Driver</p>
+                        </li>
+                        <li>
+                            <p>HTTP Client</p>
+                        </li>
+                        <li>
+                            <p>HttpUnit</p>
+                        </li>
+                        <li>
+                            <p>ICEfaces</p>
+                        </li>
+                        <li>
+                            <p>Ickenham</p>
+                        </li>
+                        <li>
+                            <p>Ignite JTA</p>
+                        </li>
+                        <li>
+                            <p>Ikasan</p>
+                        </li>
+                        <li>
+                            <p>iLog</p>
+                        </li>
+                        <li>
+                            <p>Infinispan</p>
+                        </li>
+                        <li>
+                            <p>Injekt for Kotlin</p>
+                        </li>
+                        <li>
+                            <p>Iroh</p>
+                        </li>
+                        <li>
+                            <p>Istio</p>
+                        </li>
+                        <li>
+                            <p>Jamon</p>
+                        </li>
+                        <li>
+                            <p>Jasypt</p>
+                        </li>
+                        <li>
+                            <p>Java EE Batch</p>
+                        </li>
+                        <li>
+                            <p>Java EE Batch API</p>
+                        </li>
+                        <li>
+                            <p>Java EE JACC</p>
+                        </li>
+                        <li>
+                            <p>Java EE JAXB</p>
+                        </li>
+                        <li>
+                            <p>Java EE JAXR</p>
+                        </li>
+                        <li>
+                            <p>Java EE JSON-P</p>
+                        </li>
+                        <li>
+                            <p>Java Transaction API</p>
+                        </li>
+                        <li>
+                            <p>JavaFX</p>
+                        </li>
+                        <li>
+                            <p>JavaScript</p>
+                        </li>
+                        <li>
+                            <p>Javax Inject</p>
+                        </li>
+                        <li>
+                            <p>JAX-RS</p>
+                        </li>
+                        <li>
+                            <p>JAX-WS</p>
+                        </li>
+                        <li>
+                            <p>JayWire</p>
+                        </li>
+                        <li>
+                            <p>JBehave</p>
+                        </li>
+                        <li>
+                            <p>JBoss Cache</p>
+                        </li>
+                        <li>
+                            <p>JBoss EJB XML</p>
+                        </li>
+                        <li>
+                            <p>JBoss logging</p>
+                        </li>
+                        <li>
+                            <p>JBoss Transactions</p>
+                        </li>
+                        <li>
+                            <p>JBoss Web XML</p>
+                        </li>
+                        <li>
+                            <p>JBossMQ Client</p>
+                        </li>
+                        <li>
+                            <p>JBPM</p>
+                        </li>
+                        <li>
+                            <p>JCA</p>
+                        </li>
+                        <li>
+                            <p>Jcabi Log</p>
+                        </li>
+                        <li>
+                            <p>JCache</p>
+                        </li>
+                        <li>
+                            <p>JCunit</p>
+                        </li>
+                        <li>
+                            <p>JDBC</p>
+                        </li>
+                        <li>
+                            <p>JDBC datasources</p>
+                        </li>
+                        <li>
+                            <p>JDBC XA datasources</p>
+                        </li>
+                        <li>
+                            <p>Jersey</p>
+                        </li>
+                        <li>
+                            <p>Jetbrick Template</p>
+                        </li>
+                        <li>
+                            <p>Jetty</p>
+                        </li>
+                        <li>
+                            <p>JFreeChart</p>
+                        </li>
+                        <li>
+                            <p>JFunk</p>
+                        </li>
+                        <li>
+                            <p>JGoodies</p>
+                        </li>
+                        <li>
+                            <p>JMock</p>
+                        </li>
+                        <li>
+                            <p>JMockit</p>
+                        </li>
+                        <li>
+                            <p>JMS Connection Factory</p>
+                        </li>
+                        <li>
+                            <p>JMS Queue</p>
+                        </li>
+                        <li>
+                            <p>JMS Topic</p>
+                        </li>
+                        <li>
+                            <p>JMustache</p>
+                        </li>
+                        <li>
+                            <p>JNA</p>
+                        </li>
+                        <li>
+                            <p>JNI</p>
+                        </li>
+                        <li>
+                            <p>JNLP</p>
+                        </li>
+                        <li>
+                            <p>JPA entities</p>
+                        </li>
+                        <li>
+                            <p>JPA Matchers</p>
+                        </li>
+                        <li>
+                            <p>JPA named queries</p>
+                        </li>
+                        <li>
+                            <p>JPA XML</p>
+                        </li>
+                        <li>
+                            <p>JSecurity</p>
+                        </li>
+                        <li>
+                            <p>JSF</p>
+                        </li>
+                        <li>
+                            <p>JSF Page</p>
+                        </li>
+                        <li>
+                            <p>JSilver</p>
+                        </li>
+                        <li>
+                            <p>JSON-B</p>
+                        </li>
+                        <li>
+                            <p>JSP Page</p>
+                        </li>
+                        <li>
+                            <p>JSTL</p>
+                        </li>
+                        <li>
+                            <p>JTA</p>
+                        </li>
+                        <li>
+                            <p>Jukito</p>
+                        </li>
+                        <li>
+                            <p>JUnit</p>
+                        </li>
+                        <li>
+                            <p>Ka DI</p>
+                        </li>
+                        <li>
+                            <p>Keyczar</p>
+                        </li>
+                        <li>
+                            <p>Kibana</p>
+                        </li>
+                        <li>
+                            <p>KLogger</p>
+                        </li>
+                        <li>
+                            <p>Kodein</p>
+                        </li>
+                        <li>
+                            <p>Kotlin Logging</p>
+                        </li>
+                        <li>
+                            <p>KouInject</p>
+                        </li>
+                        <li>
+                            <p>KumuluzEE JTA</p>
+                        </li>
+                        <li>
+                            <p>LevelDB Client</p>
+                        </li>
+                        <li>
+                            <p>Liferay</p>
+                        </li>
+                        <li>
+                            <p>LiferayFaces</p>
+                        </li>
+                        <li>
+                            <p>Lift JTA</p>
+                        </li>
+                        <li>
+                            <p>Log.io</p>
+                        </li>
+                        <li>
+                            <p>Log4J</p>
+                        </li>
+                        <li>
+                            <p>Log4s</p>
+                        </li>
+                        <li>
+                            <p>Logback</p>
+                        </li>
+                        <li>
+                            <p>Logging Utils</p>
+                        </li>
+                        <li>
+                            <p>Logstash</p>
+                        </li>
+                        <li>
+                            <p>Lumberjack</p>
+                        </li>
+                        <li>
+                            <p>Macros</p>
+                        </li>
+                        <li>
+                            <p>Magicgrouplayout</p>
+                        </li>
+                        <li>
+                            <p>Mail</p>
+                        </li>
+                        <li>
+                            <p>Management EJB</p>
+                        </li>
+                        <li>
+                            <p>MapR</p>
+                        </li>
+                        <li>
+                            <p>MckoiSQLDB Driver</p>
+                        </li>
+                        <li>
+                            <p>Memcached</p>
+                        </li>
+                        <li>
+                            <p>Message (MDB)</p>
+                        </li>
+                        <li>
+                            <p>Micro DI</p>
+                        </li>
+                        <li>
+                            <p>Micrometer</p>
+                        </li>
+                        <li>
+                            <p>Microsoft SQL Driver</p>
+                        </li>
+                        <li>
+                            <p>MiGLayout</p>
+                        </li>
+                        <li>
+                            <p>MinLog</p>
+                        </li>
+                        <li>
+                            <p>Mixer</p>
+                        </li>
+                        <li>
+                            <p>Mockito</p>
+                        </li>
+                        <li>
+                            <p>MongoDB Client</p>
+                        </li>
+                        <li>
+                            <p>Monolog</p>
+                        </li>
+                        <li>
+                            <p>Morphia</p>
+                        </li>
+                        <li>
+                            <p>MRules</p>
+                        </li>
+                        <li>
+                            <p>Mule</p>
+                        </li>
+                        <li>
+                            <p>Mule Functional Test Framework</p>
+                        </li>
+                        <li>
+                            <p>MultithreadedTC</p>
+                        </li>
+                        <li>
+                            <p>Mycontainer JTA</p>
+                        </li>
+                        <li>
+                            <p>MyFaces</p>
+                        </li>
+                        <li>
+                            <p>MySQL Driver</p>
+                        </li>
+                        <li>
+                            <p>Narayana Arjuna</p>
+                        </li>
+                        <li>
+                            <p>Needle</p>
+                        </li>
+                        <li>
+                            <p>Neo4j</p>
+                        </li>
+                        <li>
+                            <p>NLOG4J</p>
+                        </li>
+                        <li>
+                            <p>Nuxeo JTA/JCA</p>
+                        </li>
+                        <li>
+                            <p>OACC</p>
+                        </li>
+                        <li>
+                            <p>OAUTH</p>
+                        </li>
+                        <li>
+                            <p>OCPsoft Logging Utils</p>
+                        </li>
+                        <li>
+                            <p>OmniFaces</p>
+                        </li>
+                        <li>
+                            <p>OpenFaces</p>
+                        </li>
+                        <li>
+                            <p>OpenPojo</p>
+                        </li>
+                        <li>
+                            <p>OpenSAML</p>
+                        </li>
+                        <li>
+                            <p>OpenWS</p>
+                        </li>
+                        <li>
+                            <p>OPS4J Pax Logging Service</p>
+                        </li>
+                        <li>
+                            <p>Oracle ADF</p>
+                        </li>
+                        <li>
+                            <p>Oracle DB Driver</p>
+                        </li>
+                        <li>
+                            <p>Oracle Forms</p>
+                        </li>
+                        <li>
+                            <p>Orion EJB XML</p>
+                        </li>
+                        <li>
+                            <p>Orion Web XML</p>
+                        </li>
+                        <li>
+                            <p>Oscache</p>
+                        </li>
+                        <li>
+                            <p>OTR4J</p>
+                        </li>
+                        <li>
+                            <p>OW2 JTA</p>
+                        </li>
+                        <li>
+                            <p>OW2 Log Util</p>
+                        </li>
+                        <li>
+                            <p>OWASP CSRF Guard</p>
+                        </li>
+                        <li>
+                            <p>OWASP ESAPI</p>
+                        </li>
+                        <li>
+                            <p>Peaberry</p>
+                        </li>
+                        <li>
+                            <p>Pega</p>
+                        </li>
+                        <li>
+                            <p>Persistence units</p>
+                        </li>
+                        <li>
+                            <p>Petals EIP</p>
+                        </li>
+                        <li>
+                            <p>PicketBox</p>
+                        </li>
+                        <li>
+                            <p>PicketLink</p>
+                        </li>
+                        <li>
+                            <p>PicoContainer</p>
+                        </li>
+                        <li>
+                            <p>Play</p>
+                        </li>
+                        <li>
+                            <p>Play Test</p>
+                        </li>
+                        <li>
+                            <p>Plexus Container</p>
+                        </li>
+                        <li>
+                            <p>Polyforms DI</p>
+                        </li>
+                        <li>
+                            <p>Portlet</p>
+                        </li>
+                        <li>
+                            <p>PostgreSQL Driver</p>
+                        </li>
+                        <li>
+                            <p>PowerMock</p>
+                        </li>
+                        <li>
+                            <p>PrimeFaces</p>
+                        </li>
+                        <li>
+                            <p>Properties</p>
+                        </li>
+                        <li>
+                            <p>Qpid Client</p>
+                        </li>
+                        <li>
+                            <p>RabbitMQ Client</p>
+                        </li>
+                        <li>
+                            <p>RandomizedTesting Runner</p>
+                        </li>
+                        <li>
+                            <p>Resource Adapter</p>
+                        </li>
+                        <li>
+                            <p>REST Assured</p>
+                        </li>
+                        <li>
+                            <p>Restito</p>
+                        </li>
+                        <li>
+                            <p>RichFaces</p>
+                        </li>
+                        <li>
+                            <p>RMI</p>
+                        </li>
+                        <li>
+                            <p>RocketMQ Client</p>
+                        </li>
+                        <li>
+                            <p>Rythm Template Engine</p>
+                        </li>
+                        <li>
+                            <p>SAML</p>
+                        </li>
+                        <li>
+                            <p>Santuario</p>
+                        </li>
+                        <li>
+                            <p>Scalate</p>
+                        </li>
+                        <li>
+                            <p>Scaldi</p>
+                        </li>
+                        <li>
+                            <p>Scribe</p>
+                        </li>
+                        <li>
+                            <p>Seam</p>
+                        </li>
+                        <li>
+                            <p>Security Realm</p>
+                        </li>
+                        <li>
+                            <p>ServiceMix</p>
+                        </li>
+                        <li>
+                            <p>Servlet</p>
+                        </li>
+                        <li>
+                            <p>ShiftOne</p>
+                        </li>
+                        <li>
+                            <p>Shiro</p>
+                        </li>
+                        <li>
+                            <p>Silk DI</p>
+                        </li>
+                        <li>
+                            <p>SLF4J</p>
+                        </li>
+                        <li>
+                            <p>Snippetory Template Engine</p>
+                        </li>
+                        <li>
+                            <p>SNMP4J</p>
+                        </li>
+                        <li>
+                            <p>Socket handler logging</p>
+                        </li>
+                        <li>
+                            <p>Spark</p>
+                        </li>
+                        <li>
+                            <p>Specsy</p>
+                        </li>
+                        <li>
+                            <p>Spock</p>
+                        </li>
+                        <li>
+                            <p>Spring</p>
+                        </li>
+                        <li>
+                            <p>Spring Batch</p>
+                        </li>
+                        <li>
+                            <p>Spring Boot</p>
+                        </li>
+                        <li>
+                            <p>Spring Boot Actuator</p>
+                        </li>
+                        <li>
+                            <p>Spring Boot Cache</p>
+                        </li>
+                        <li>
+                            <p>Spring Boot Flo</p>
+                        </li>
+                        <li>
+                            <p>Spring Cloud Config</p>
+                        </li>
+                        <li>
+                            <p>Spring Cloud Function</p>
+                        </li>
+                        <li>
+                            <p>Spring Data</p>
+                        </li>
+                        <li>
+                            <p>Spring Data JPA</p>
+                        </li>
+                        <li>
+                            <p>spring DI</p>
+                        </li>
+                        <li>
+                            <p>Spring Integration</p>
+                        </li>
+                        <li>
+                            <p>Spring JMX</p>
+                        </li>
+                        <li>
+                            <p>Spring Messaging Client</p>
+                        </li>
+                        <li>
+                            <p>Spring MVC</p>
+                        </li>
+                        <li>
+                            <p>Spring Properties</p>
+                        </li>
+                        <li>
+                            <p>Spring Scheduled</p>
+                        </li>
+                        <li>
+                            <p>Spring Security</p>
+                        </li>
+                        <li>
+                            <p>Spring Shell</p>
+                        </li>
+                        <li>
+                            <p>Spring Test</p>
+                        </li>
+                        <li>
+                            <p>Spring Transactions</p>
+                        </li>
+                        <li>
+                            <p>Spring Web</p>
+                        </li>
+                        <li>
+                            <p>SQLite Driver</p>
+                        </li>
+                        <li>
+                            <p>SSL</p>
+                        </li>
+                        <li>
+                            <p>Standard Widget Toolkit (SWT)</p>
+                        </li>
+                        <li>
+                            <p>Stateful (SFSB)</p>
+                        </li>
+                        <li>
+                            <p>Stateless (SLSB)</p>
+                        </li>
+                        <li>
+                            <p>Sticky Configured</p>
+                        </li>
+                        <li>
+                            <p>Stripes</p>
+                        </li>
+                        <li>
+                            <p>Struts</p>
+                        </li>
+                        <li>
+                            <p>SubCut</p>
+                        </li>
+                        <li>
+                            <p>Swagger</p>
+                        </li>
+                        <li>
+                            <p>SwarmCache</p>
+                        </li>
+                        <li>
+                            <p>Swing</p>
+                        </li>
+                        <li>
+                            <p>SwitchYard</p>
+                        </li>
+                        <li>
+                            <p>Syringe</p>
+                        </li>
+                        <li>
+                            <p>Talend ESB</p>
+                        </li>
+                        <li>
+                            <p>Teiid</p>
+                        </li>
+                        <li>
+                            <p>TensorFlow</p>
+                        </li>
+                        <li>
+                            <p>Test Interface</p>
+                        </li>
+                        <li>
+                            <p>TestNG</p>
+                        </li>
+                        <li>
+                            <p>Thymeleaf</p>
+                        </li>
+                        <li>
+                            <p>TieFaces</p>
+                        </li>
+                        <li>
+                            <p>tinylog</p>
+                        </li>
+                        <li>
+                            <p>Tomcat</p>
+                        </li>
+                        <li>
+                            <p>Tornado Inject</p>
+                        </li>
+                        <li>
+                            <p>Trimou</p>
+                        </li>
+                        <li>
+                            <p>Trunk JGuard</p>
+                        </li>
+                        <li>
+                            <p>Twirl</p>
+                        </li>
+                        <li>
+                            <p>Twitter Util Logging</p>
+                        </li>
+                        <li>
+                            <p>UberFire</p>
+                        </li>
+                        <li>
+                            <p>Unirest</p>
+                        </li>
+                        <li>
+                            <p>Unitils</p>
+                        </li>
+                        <li>
+                            <p>Vaadin</p>
+                        </li>
+                        <li>
+                            <p>Velocity</p>
+                        </li>
+                        <li>
+                            <p>Vlad</p>
+                        </li>
+                        <li>
+                            <p>Water Template Engine</p>
+                        </li>
+                        <li>
+                            <p>Web Services Metadata</p>
+                        </li>
+                        <li>
+                            <p>Web Session</p>
+                        </li>
+                        <li>
+                            <p>Web XML File</p>
+                        </li>
+                        <li>
+                            <p>WebLogic Web XML</p>
+                        </li>
+                        <li>
+                            <p>Webmacro</p>
+                        </li>
+                        <li>
+                            <p>WebSocket</p>
+                        </li>
+                        <li>
+                            <p>WebSphere EJB</p>
+                        </li>
+                        <li>
+                            <p>WebSphere EJB Ext</p>
+                        </li>
+                        <li>
+                            <p>WebSphere Web XML</p>
+                        </li>
+                        <li>
+                            <p>WebSphere WS Binding</p>
+                        </li>
+                        <li>
+                            <p>WebSphere WS Extension</p>
+                        </li>
+                        <li>
+                            <p>Weka</p>
+                        </li>
+                        <li>
+                            <p>Weld</p>
+                        </li>
+                        <li>
+                            <p>WF Core JTA</p>
+                        </li>
+                        <li>
+                            <p>Wicket</p>
+                        </li>
+                        <li>
+                            <p>Winter</p>
+                        </li>
+                        <li>
+                            <p>WSDL</p>
+                        </li>
+                        <li>
+                            <p>WSO2</p>
+                        </li>
+                        <li>
+                            <p>WSS4J</p>
+                        </li>
+                        <li>
+                            <p>XACML</p>
+                        </li>
+                        <li>
+                            <p>XFire</p>
+                        </li>
+                        <li>
+                            <p>XMLUnit</p>
+                        </li>
+                        <li>
+                            <p>Zbus Client</p>
+                        </li>
+                        <li>
+                            <p>Zipkin</p>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="about-story-points_cli-guide">A.3. About rule story points</h3>
+                <div class="sect3">
+                    <h4 id="_what_are_story_points">A.3.1. What are story points?</h4>
+                    <div class="paragraph">
+                        <p><em>Story points</em> are an abstract metric commonly used in Agile software development to estimate the <em>level of effort</em> needed to implement a feature or change.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The Azure Migrate application and code assessment for Java uses story points to express the level of effort needed to migrate particular application constructs, and the application as a whole. It does not necessarily translate to man-hours, but the value should be consistent across tasks.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_how_story_points_are_estimated_in_rules">A.3.2. How story points are estimated in rules</h4>
+                    <div class="paragraph">
+                        <p>Estimating the level of effort for the story points for a rule can be tricky. The following are the general guidelines APPCAT uses when estimating the level of effort required for a rule.</p>
+                    </div>
+                    <table class="tableblock frame-all grid-all stretch">
+                        <colgroup>
+                            <col style="width: 25%;">
+                            <col style="width: 15%;">
+                            <col style="width: 60%;">
+                        </colgroup>
+                        <thead>
+                        <tr>
+                            <th class="tableblock halign-left valign-top">Level of Effort</th>
+                            <th class="tableblock halign-left valign-top">Story Points</th>
+                            <th class="tableblock halign-left valign-top">Description</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Information</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">An informational warning with very low or no priority for migration.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Trivial</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration is a trivial change or a simple library swap with no or minimal API changes.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Complex</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The changes required for the migration task are complex, but have a documented solution.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Redesign</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration task requires a redesign or a complete library change, with significant API changes.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Rearchitecture</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration requires a complete rearchitecture of the component or subsystem.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Unknown</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">13</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration solution is not known and may need a complete rewrite.</p></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="sect3">
+                    <h4 id="_task_category">A.3.3. Task category</h4>
+                    <div class="paragraph">
+                        <p>In addition to the level of effort, you can categorize migration tasks to indicate the severity of the task. The following categories are used to group issues to help prioritize the migration effort.</p>
+                    </div>
+                    <div class="dlist">
+                        <dl>
+                            <dt class="hdlist1">Mandatory</dt>
+                            <dd>
+                                <p>The task must be completed for a successful migration. If the changes are not made, the resulting application will not build or run successfully. Examples include replacement of proprietary APIs that are not supported in the target platform.</p>
+                            </dd>
+                            <dt class="hdlist1">Optional</dt>
+                            <dd>
+                                <p>If the migration task is not completed, the application should work, but the results may not be optimal. If the change is not made at the time of migration, it is recommended to put it on the schedule soon after your migration is completed. An example of this would be the upgrade of EJB 2.x code to EJB 3.</p>
+                            </dd>
+                            <dt class="hdlist1">Potential</dt>
+                            <dd>
+                                <p>The task should be examined during the migration process, but there is not enough detailed information to determine if the task is mandatory for the migration to succeed. An example of this would be migrating a third-party proprietary type where there is no directly compatible type.</p>
+                            </dd>
+                            <dt class="hdlist1">Information</dt>
+                            <dd>
+                                <p>The task is included to inform you of the existence of certain files. These may need to be examined or modified as part of the modernization effort, but changes are typically not required. An example of this would be the presence of a logging dependency or a Maven <code>pom.xml</code>.</p>
+                            </dd>
+                        </dl>
+                    </div>
+                    <div class="paragraph">
+                        <p>For more information on categorizing tasks, see <a href="https://azure.github.io/appcat-docs/rules-development-guide/#rule_categories_rules-development-guide">Using custom rule categories</a>.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_additional_resources">A.4. Additional Resources</h3>
+                <div class="sect3">
+                    <h4 id="get-involved_cli-guide">A.4.1. Getting involved</h4>
+                    <div class="paragraph">
+                        <p>To help the Azure Migrate application and code assessment for Java cover most application constructs and server configurations, including yours, you can help with any of the following items.</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>Send an email to <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a> and let us know what APPCAT migration rules should cover.</p>
+                            </li>
+                            <li>
+                                <p>You can also contribute by providing feedback directly to our GitHub project at <a href="https://github.com/Azure/appcat-rulesets/issues">https://github.com/Azure/appcat-rulesets/issues</a>.</p>
+                            </li>
+                            <li>
+                                <p>Provide example applications to test migration rules.</p>
+                            </li>
+                            <li>
+                                <p>Identify application components and problem areas that may be difficult to migrate.</p>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p>Write a short description of these problem migration areas.</p>
+                                        </li>
+                                        <li>
+                                            <p>Write a brief overview describing how to solve the problem migration areas.</p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                            <li>
+                                <p>Try Azure Migrate application and code assessment for Java on your application. Be sure to report any issues you encounter.</p>
+                            </li>
+                            <li>
+                                <p>Contribute to the Azure Migrate application and code assessment for Java rules repository.</p>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p>Write a Azure Migrate application and code assessment for Java rule to identify or automate a migration process.</p>
+                                        </li>
+                                        <li>
+                                            <p>Create a test for the new rule.</p>
+                                        </li>
+                                        <li>
+                                            <p>Details are provided in the <a href="https://access.redhat.com/documentation/en-us/migration_toolkit_for_applications/6.1/html-single/rules_development_guide"><em>Rules Development Guide</em></a>.</p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                            <li>
+                                <p>Contribute to the project source code.</p>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p>Create a core rule.</p>
+                                        </li>
+                                        <li>
+                                            <p>Improve APPCAT performance or efficiency.</p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p>Any level of involvement is greatly appreciated!</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="important-links_cli-guide">A.4.2. Resources</h4>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>GitHub issues: <a href="https://github.com/Azure/appcat-rulesets/issues" class="bare">https://github.com/Azure/appcat-rulesets/issues</a></p>
+                            </li>
+                            <li>
+                                <p>Contact the APPCAT team at: <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a></p>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_reporting_issues">A.4.3. Reporting issues</h4>
+                    <div class="paragraph">
+                        <p>APPCAT uses GitHub as its issue tracking system. If you encounter an issue executing APPCAT, submit a <a href="https://github.com/Azure/appcat-rulesets/issues">an issue</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p><br>
+                            <br>
+                            <br>
+                            <br></p>
+                    </div>
+                    <div class="paragraph">
+                        <p><em class="right">Revised on 2023-11-14 15:17:32 UTC</em></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 <div id="footer">
-<div id="footer-text">
-Last updated 2023-08-08 02:32:13 UTC
-</div>
+    <div id="footer-text">
+        Last updated 2023-11-14 15:17:26 UTC
+    </div>
 </div>
 </body>
 </html>

--- a/docs/rules-development-guide/index.html
+++ b/docs/rules-development-guide/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
-<meta name="author" content="Rules Development Guide (Version: 6.3.0)">
-<title>Azure Application and Code Assessment Toolkit</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
-<style>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="Asciidoctor 2.0.10">
+    <meta name="author" content="Rules Development Guide (Version: 6.3.0)">
+    <title>Azure Migrate application and code assessment for Java</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+    <style>
 /* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment @import statement to use as custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
@@ -439,209 +439,209 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </head>
 <body class="book">
 <div id="header">
-<h1>Azure Application and Code Assessment Toolkit</h1>
-<div class="details">
-<span id="author" class="author">Rules Development Guide (Version: 6.3.0)</span><br>
-</div>
-<div id="toc" class="toc">
-<div id="toctitle">Table of Contents</div>
-<ul class="sectlevel1">
-<li><a href="#_introduction">1. Introduction</a>
-<ul class="sectlevel2">
-<li><a href="#rules-guide-intro_rules-development-guide-appcat">1.1. About the Rules Development Guide</a>
-<ul class="sectlevel3">
-<li><a href="#about-home-var_rules-development-guide-appcat">1.1.1. Use of <code>&lt;APPCAT_HOME&gt;</code> in this guide</a></li>
-</ul>
-</li>
-<li><a href="#about-rules_rules-development-guide-appcat">1.2. About APPCAT rules</a></li>
-</ul>
-</li>
-<li><a href="#getting-started-rules_rules-development-guide-appcat">2. Getting started with rules</a>
-<ul class="sectlevel2">
-<li><a href="#create-first-xml-rule_rules-development-guide-appcat">2.1. Creating your first XML rule</a></li>
-<li><a href="#review-quickstarts_rules-development-guide-appcat">2.2. Reviewing the Azure Application and Code Assessment Toolkit quickstarts</a></li>
-</ul>
-</li>
-<li><a href="#_creating_xml_rules">3. Creating XML rules</a>
-<ul class="sectlevel2">
-<li><a href="#xml-rule-syntax_rules-development-guide-appcat">3.1. XML rule structure</a>
-<ul class="sectlevel3">
-<li><a href="#_rulesets">3.1.1. Rulesets</a></li>
-<li><a href="#_predefined_rules">3.1.2. Predefined rules</a></li>
-</ul>
-</li>
-<li><a href="#create-basic-xml-rule_rules-development-guide-appcat">3.2. Creating a basic XML rule</a>
-<ul class="sectlevel3">
-<li><a href="#_creating_a_basic_xml_rule_template">3.2.1. Creating a basic XML rule template</a></li>
-<li><a href="#_creating_the_ruleset_metadata">3.2.2. Creating the ruleset metadata</a></li>
-<li><a href="#_creating_a_rule">3.2.3. Creating a rule</a></li>
-</ul>
-</li>
-<li><a href="#_xml_rule_syntax">3.3. XML rule syntax</a>
-<ul class="sectlevel3">
-<li><a href="#xml-rule-when-syntax_rules-development-guide-appcat">3.3.1. <code>&lt;when&gt;</code> syntax</a></li>
-<li><a href="#xml-rule-perform-syntax_rules-development-guide-appcat">3.3.2. <code>&lt;perform&gt;</code> syntax</a></li>
-<li><a href="#where-syntax_rules-development-guide-appcat">3.3.3. <code>&lt;where&gt;</code> syntax</a></li>
-</ul>
-</li>
-<li><a href="#add-rule-to-mtr_rules-development-guide-appcat">3.4. Adding a rule to the Azure Application and Code Assessment Toolkit</a></li>
-</ul>
-</li>
-<li><a href="#testing-rules_rules-development-guide-appcat">4. Testing XML rules</a>
-<ul class="sectlevel2">
-<li><a href="#_creating_a_test_rule">4.1. Creating a test rule</a>
-<ul class="sectlevel3">
-<li><a href="#test-xml-rule-structure_rules-development-guide-appcat">4.1.1. Test XML rule structure</a></li>
-<li><a href="#_test_xml_rule_syntax">4.1.2. Test XML rule syntax</a></li>
-</ul>
-</li>
-<li><a href="#manually-test-rules_rules-development-guide-appcat">4.2. Manually testing an XML rule</a></li>
-<li><a href="#rules-testng-junit_rules-development-guide-appcat">4.3. Testing the rules by using JUnit</a></li>
-<li><a href="#validation-report_rules-development-guide-appcat">4.4. About validation reports</a>
-<ul class="sectlevel3">
-<li><a href="#validation-report-understanding_rules-development-guide-appcat">4.4.1. Creating a validation report</a></li>
-<li><a href="#validation-report-errors_rules-development-guide-appcat">4.4.2. Validation report error messages</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#overriding-rules_rules-development-guide-appcat">5. Overriding rules</a>
-<ul class="sectlevel2">
-<li><a href="#_overriding_a_rule">5.1. Overriding a rule</a></li>
-<li><a href="#_disabling_a_rule">5.2. Disabling a rule</a></li>
-</ul>
-</li>
-<li><a href="#rule-categories_rules-development-guide-appcat">6. Using custom rule categories</a></li>
-<li><a href="#_reference_material">Appendix A: Reference material</a>
-<ul class="sectlevel2">
-<li><a href="#about-story-points_rules-development-guide-appcat">A.1. About rule story points</a>
-<ul class="sectlevel3">
-<li><a href="#_what_are_story_points">A.1.1. What are story points?</a></li>
-<li><a href="#_how_story_points_are_estimated_in_rules">A.1.2. How story points are estimated in rules</a></li>
-<li><a href="#_task_category">A.1.3. Task category</a></li>
-</ul>
-</li>
-<li><a href="#_additional_resources">A.2. Additional resources</a>
-<ul class="sectlevel3">
-<li><a href="#review-existing-rules_rules-development-guide-appcat">A.2.1. Reviewing existing APPCAT XML rules</a></li>
-<li><a href="#rules-important-links_rules-development-guide-appcat">A.2.2. Additional resources</a></li>
-</ul>
-</li>
-</ul>
-</li>
-</ul>
-</div>
+    <h1>Azure Migrate application and code assessment for Java</h1>
+    <div class="details">
+        <span id="author" class="author">Rules Development Guide (Version: 6.3.0)</span><br>
+    </div>
+    <div id="toc" class="toc">
+        <div id="toctitle">Table of Contents</div>
+        <ul class="sectlevel1">
+            <li><a href="#_introduction">1. Introduction</a>
+                <ul class="sectlevel2">
+                    <li><a href="#rules-guide-intro_rules-development-guide-appcat">1.1. About the Rules Development Guide</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#about-home-var_rules-development-guide-appcat">1.1.1. Use of <code>&lt;APPCAT_HOME&gt;</code> in this guide</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#about-rules_rules-development-guide-appcat">1.2. About APPCAT rules</a></li>
+                </ul>
+            </li>
+            <li><a href="#getting-started-rules_rules-development-guide-appcat">2. Getting started with rules</a>
+                <ul class="sectlevel2">
+                    <li><a href="#create-first-xml-rule_rules-development-guide-appcat">2.1. Creating your first XML rule</a></li>
+                    <li><a href="#review-quickstarts_rules-development-guide-appcat">2.2. Reviewing the Azure Migrate application and code assessment for Java quickstarts</a></li>
+                </ul>
+            </li>
+            <li><a href="#_creating_xml_rules">3. Creating XML rules</a>
+                <ul class="sectlevel2">
+                    <li><a href="#xml-rule-syntax_rules-development-guide-appcat">3.1. XML rule structure</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#_rulesets">3.1.1. Rulesets</a></li>
+                            <li><a href="#_predefined_rules">3.1.2. Predefined rules</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#create-basic-xml-rule_rules-development-guide-appcat">3.2. Creating a basic XML rule</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#_creating_a_basic_xml_rule_template">3.2.1. Creating a basic XML rule template</a></li>
+                            <li><a href="#_creating_the_ruleset_metadata">3.2.2. Creating the ruleset metadata</a></li>
+                            <li><a href="#_creating_a_rule">3.2.3. Creating a rule</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#_xml_rule_syntax">3.3. XML rule syntax</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#xml-rule-when-syntax_rules-development-guide-appcat">3.3.1. <code>&lt;when&gt;</code> syntax</a></li>
+                            <li><a href="#xml-rule-perform-syntax_rules-development-guide-appcat">3.3.2. <code>&lt;perform&gt;</code> syntax</a></li>
+                            <li><a href="#where-syntax_rules-development-guide-appcat">3.3.3. <code>&lt;where&gt;</code> syntax</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#add-rule-to-mtr_rules-development-guide-appcat">3.4. Adding a rule to the Azure Migrate application and code assessment for Java</a></li>
+                </ul>
+            </li>
+            <li><a href="#testing-rules_rules-development-guide-appcat">4. Testing XML rules</a>
+                <ul class="sectlevel2">
+                    <li><a href="#_creating_a_test_rule">4.1. Creating a test rule</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#test-xml-rule-structure_rules-development-guide-appcat">4.1.1. Test XML rule structure</a></li>
+                            <li><a href="#_test_xml_rule_syntax">4.1.2. Test XML rule syntax</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#manually-test-rules_rules-development-guide-appcat">4.2. Manually testing an XML rule</a></li>
+                    <li><a href="#rules-testng-junit_rules-development-guide-appcat">4.3. Testing the rules by using JUnit</a></li>
+                    <li><a href="#validation-report_rules-development-guide-appcat">4.4. About validation reports</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#validation-report-understanding_rules-development-guide-appcat">4.4.1. Creating a validation report</a></li>
+                            <li><a href="#validation-report-errors_rules-development-guide-appcat">4.4.2. Validation report error messages</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li><a href="#overriding-rules_rules-development-guide-appcat">5. Overriding rules</a>
+                <ul class="sectlevel2">
+                    <li><a href="#_overriding_a_rule">5.1. Overriding a rule</a></li>
+                    <li><a href="#_disabling_a_rule">5.2. Disabling a rule</a></li>
+                </ul>
+            </li>
+            <li><a href="#rule-categories_rules-development-guide-appcat">6. Using custom rule categories</a></li>
+            <li><a href="#_reference_material">Appendix A: Reference material</a>
+                <ul class="sectlevel2">
+                    <li><a href="#about-story-points_rules-development-guide-appcat">A.1. About rule story points</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#_what_are_story_points">A.1.1. What are story points?</a></li>
+                            <li><a href="#_how_story_points_are_estimated_in_rules">A.1.2. How story points are estimated in rules</a></li>
+                            <li><a href="#_task_category">A.1.3. Task category</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="#_additional_resources">A.2. Additional resources</a>
+                        <ul class="sectlevel3">
+                            <li><a href="#review-existing-rules_rules-development-guide-appcat">A.2.1. Reviewing existing APPCAT XML rules</a></li>
+                            <li><a href="#rules-important-links_rules-development-guide-appcat">A.2.2. Additional resources</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
 </div>
 <div id="content">
-<div class="sect1">
-<h2 id="_introduction">1. Introduction</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="rules-guide-intro_rules-development-guide-appcat">1.1. About the Rules Development Guide</h3>
-<div class="paragraph">
-<p>This guide is for engineers, consultants, and others who want to create custom XML-based rules for Azure Application and Code Assessment Toolkit (APPCAT) tools.</p>
-</div>
-<div class="paragraph">
-<p>For more information, see the <a href="https://learn.microsoft.com/en-ca/azure/developer/java/migration/appcat"><em>Introduction to the Application and Code Assessment Toolkit</em></a> for an overview and the <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a> for details.</p>
-</div>
-<div class="sect3">
-<h4 id="about-home-var_rules-development-guide-appcat">1.1.1. Use of <code>&lt;APPCAT_HOME&gt;</code> in this guide</h4>
-<div class="paragraph">
-<p>This guide uses the <code>&lt;APPCAT_HOME&gt;</code> replaceable variable to denote the path to your APPCAT installation. The installation directory is the <code>azure-appcat-cli-6.3.0</code> directory where you extracted the APPCAT <code>.zip</code> file.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>If you are installing on a Windows operating system:</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Extract the <code>.zip</code> file to a folder named <code>appcat</code> to avoid a <code>Path too long</code> error. Alternatively, extract the file with <a href="https://www.7-zip.org/download.html">7-Zip</a> to a folder of any name you choose.</p>
-</li>
-<li>
-<p>If a <strong>Confirm file replace</strong> window is displayed during extraction, click <strong>Yes to all</strong>.</p>
-</li>
-</ol>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>When you encounter <code>&lt;APPCAT_HOME&gt;</code> in this guide, replace it with the actual path to your APPCAT installation.</p>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="about-rules_rules-development-guide-appcat">1.2. About APPCAT rules</h3>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit (APPCAT) contains rule-based migration tools that analyze the APIs, technologies, and architectures used by the applications you plan to migrate. In fact, the APPCAT analysis process is implemented using APPCAT rules. APPCAT uses rules internally to extract files from archives, decompile files, scan and classify file types, analyze XML and other file content, analyze the application code, and build the reports.</p>
-</div>
-<div class="paragraph">
-<p>APPCAT builds a data model based on the rule execution results and stores component data and relationships in a graph database, which can then be queried and updated as needed by the migration rules and for reporting purposes.</p>
-</div>
-<div class="paragraph">
-<p>APPCAT rules use the following rule pattern:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+    <div class="sect1">
+        <h2 id="_introduction">1. Introduction</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="rules-guide-intro_rules-development-guide-appcat">1.1. About the Rules Development Guide</h3>
+                <div class="paragraph">
+                    <p>This guide is for engineers, consultants, and others who want to create custom XML-based rules for Azure Migrate application and code assessment for Java (APPCAT) tools.</p>
+                </div>
+                <div class="paragraph">
+                    <p>For more information, see the <a href="https://learn.microsoft.com/en-ca/azure/developer/java/migration/appcat"><em>Introduction to the Azure Migrate application and code assessment for Java</em></a> for an overview and the <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a> for details.</p>
+                </div>
+                <div class="sect3">
+                    <h4 id="about-home-var_rules-development-guide-appcat">1.1.1. Use of <code>&lt;APPCAT_HOME&gt;</code> in this guide</h4>
+                    <div class="paragraph">
+                        <p>This guide uses the <code>&lt;APPCAT_HOME&gt;</code> replaceable variable to denote the path to your APPCAT installation. The installation directory is the <code>azure-migrate-appcat-for-java-cli-6.3.0</code> directory where you extracted the APPCAT <code>.zip</code> file.</p>
+                    </div>
+                    <div class="admonitionblock note">
+                        <table>
+                            <tr>
+                                <td class="icon">
+                                    <div class="title">Note</div>
+                                </td>
+                                <td class="content">
+                                    <div class="paragraph">
+                                        <p>If you are installing on a Windows operating system:</p>
+                                    </div>
+                                    <div class="olist arabic">
+                                        <ol class="arabic">
+                                            <li>
+                                                <p>Extract the <code>.zip</code> file to a folder named <code>appcat</code> to avoid a <code>Path too long</code> error. Alternatively, extract the file with <a href="https://www.7-zip.org/download.html">7-Zip</a> to a folder of any name you choose.</p>
+                                            </li>
+                                            <li>
+                                                <p>If a <strong>Confirm file replace</strong> window is displayed during extraction, click <strong>Yes to all</strong>.</p>
+                                            </li>
+                                        </ol>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="paragraph">
+                        <p>When you encounter <code>&lt;APPCAT_HOME&gt;</code> in this guide, replace it with the actual path to your APPCAT installation.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="about-rules_rules-development-guide-appcat">1.2. About APPCAT rules</h3>
+                <div class="paragraph">
+                    <p>The Azure Migrate application and code assessment for Java (APPCAT) contains rule-based migration tools that analyze the APIs, technologies, and architectures used by the applications you plan to migrate. In fact, the APPCAT analysis process is implemented using APPCAT rules. APPCAT uses rules internally to extract files from archives, decompile files, scan and classify file types, analyze XML and other file content, analyze the application code, and build the reports.</p>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT builds a data model based on the rule execution results and stores component data and relationships in a graph database, which can then be queried and updated as needed by the migration rules and for reporting purposes.</p>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT rules use the following rule pattern:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre>when(condition)
   perform(action)
 otherwise(action)</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>APPCAT provides a comprehensive set of standard migration rules out-of-the-box. Because applications may contain custom libraries or components, APPCAT allows you to write your own rules to identify use of components or software that may not be covered by the existing ruleset.</p>
-</div>
-<div class="paragraph">
-<p>If you plan to write your own custom rules, see the <a href="https://azure.github.io/appcat-docs/rules-development-guide"><em>Rules Development Guide</em></a> for detailed instructions.</p>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="getting-started-rules_rules-development-guide-appcat">2. Getting started with rules</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>You can get started creating custom APPCAT rules by creating a rule or by reviewing the quickstarts.</p>
-</div>
-<div class="sect2">
-<h3 id="create-first-xml-rule_rules-development-guide-appcat">2.1. Creating your first XML rule</h3>
-<div class="paragraph">
-<p>This section guides you through the process of creating and testing your first APPCAT XML-based rule. This assumes that you have already installed APPCAT. See <a href="https://azure.github.io/appcat-docs/cli/index#installing_and_running_the_cli">Installing and running the CLI</a> in the <em>CLI Guide</em> for installation instructions.</p>
-</div>
-<div class="paragraph">
-<p>In this example, you will write a rule to discover instances where an application defines a <code>jboss-web.xml</code> file containing a <code>&lt;class-loading&gt;</code> element and provide a link to the documentation that describes how to migrate the code.</p>
-</div>
-<h4 id="_creating_the_directory_structure_for_the_rule" class="discrete">Creating the directory structure for the rule</h4>
-<div class="paragraph">
-<p>Create a directory structure to contain your first rule and the data file to use for testing.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT provides a comprehensive set of standard migration rules out-of-the-box. Because applications may contain custom libraries or components, APPCAT allows you to write your own rules to identify use of components or software that may not be covered by the existing ruleset.</p>
+                </div>
+                <div class="paragraph">
+                    <p>If you plan to write your own custom rules, see the <a href="https://azure.github.io/appcat-docs/rules-development-guide"><em>Rules Development Guide</em></a> for detailed instructions.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="getting-started-rules_rules-development-guide-appcat">2. Getting started with rules</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>You can get started creating custom APPCAT rules by creating a rule or by reviewing the quickstarts.</p>
+            </div>
+            <div class="sect2">
+                <h3 id="create-first-xml-rule_rules-development-guide-appcat">2.1. Creating your first XML rule</h3>
+                <div class="paragraph">
+                    <p>This section guides you through the process of creating and testing your first APPCAT XML-based rule. This assumes that you have already installed APPCAT. See <a href="https://azure.github.io/appcat-docs/cli/index#installing_and_running_the_cli">Installing and running the CLI</a> in the <em>CLI Guide</em> for installation instructions.</p>
+                </div>
+                <div class="paragraph">
+                    <p>In this example, you will write a rule to discover instances where an application defines a <code>jboss-web.xml</code> file containing a <code>&lt;class-loading&gt;</code> element and provide a link to the documentation that describes how to migrate the code.</p>
+                </div>
+                <h4 id="_creating_the_directory_structure_for_the_rule" class="discrete">Creating the directory structure for the rule</h4>
+                <div class="paragraph">
+                    <p>Create a directory structure to contain your first rule and the data file to use for testing.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre class="nowrap">$ mkdir -p /home/&lt;USER_NAME&gt;/migration-rules/rules
 $ mkdir -p /home/&lt;USER_NAME&gt;/migration-rules/data</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>This directory structure will also be used to hold the generated APPCAT reports.</p>
-</div>
-<h4 id="_creating_data_to_test_the_rule" class="discrete">Creating data to test the rule</h4>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Create a <code>jboss-web.xml</code> file in the <code>/home/&lt;USER_NAME&gt;/migration-rules/data/</code> subdirectory.</p>
-</li>
-<li>
-<p>Copy in the following content.</p>
-<div class="listingblock">
-<div class="content">
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>This directory structure will also be used to hold the generated APPCAT reports.</p>
+                </div>
+                <h4 id="_creating_data_to_test_the_rule" class="discrete">Creating data to test the rule</h4>
+                <div class="olist arabic">
+                    <ol class="arabic">
+                        <li>
+                            <p>Create a <code>jboss-web.xml</code> file in the <code>/home/&lt;USER_NAME&gt;/migration-rules/data/</code> subdirectory.</p>
+                        </li>
+                        <li>
+                            <p>Copy in the following content.</p>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 4.2//EN" "http://www.jboss.org/j2ee/dtd/jboss-web_4_2.dtd"&gt;
 &lt;jboss-web&gt;
     &lt;class-loading java2ClassLoadingCompliance="false"&gt;
@@ -651,31 +651,31 @@ $ mkdir -p /home/&lt;USER_NAME&gt;/migration-rules/data</pre>
         &lt;/loader-repository&gt;
     &lt;/class-loading&gt;
 &lt;/jboss-web&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>Creating the rule</p>
-</div>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>APPCAT XML-based rules use the following rule pattern:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                            <div class="paragraph">
+                                <p>Creating the rule</p>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+                <div class="paragraph">
+                    <p>APPCAT XML-based rules use the following rule pattern:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre>when(condition)
   perform(action)
 otherwise(action)</pre>
-</div>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>In the <code>/home/&lt;USER_NAME&gt;/migration-rules/rules/</code> directory, create a file named <code>JBoss5-web-class-loading.windup.xml</code> that contains the following content:</p>
-<div class="listingblock">
-<div class="content">
+                    </div>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>In the <code>/home/&lt;USER_NAME&gt;/migration-rules/rules/</code> directory, create a file named <code>JBoss5-web-class-loading.windup.xml</code> that contains the following content:</p>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset id="&lt;UNIQUE_RULESET_ID&gt;"
   xmlns="http://windup.jboss.org/schema/jboss-ruleset"
@@ -703,100 +703,100 @@ otherwise(action)</pre>
       &lt;/rule&gt;
    &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>The XML file name must include the <code>.windup.xml</code> extension. Otherwise, APPCAT does not evaluate the new rule.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-</li>
-<li>
-<p>Add a unique identifier for the ruleset and rule:</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Replace <code>&lt;UNIQUE_RULESET_ID&gt;</code> with an appropriate ruleset ID, for example, <code>JBoss5-web-class-loading</code>.</p>
-</li>
-<li>
-<p>Replace <code>&lt;UNIQUE_RULE_ID&gt;</code> with an appropriate rule ID, for example, <code>JBoss5-web-class-loading_001</code>.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Add the following ruleset add-on dependencies:</p>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>The XML file name must include the <code>.windup.xml</code> extension. Otherwise, APPCAT does not evaluate the new rule.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Add a unique identifier for the ruleset and rule:</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Replace <code>&lt;UNIQUE_RULESET_ID&gt;</code> with an appropriate ruleset ID, for example, <code>JBoss5-web-class-loading</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p>Replace <code>&lt;UNIQUE_RULE_ID&gt;</code> with an appropriate rule ID, for example, <code>JBoss5-web-class-loading_001</code>.</p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Add the following ruleset add-on dependencies:</p>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;dependencies&gt;
   &lt;addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"/&gt;
   &lt;addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/&gt;
 &lt;/dependencies&gt;</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>Add the source and target technologies:</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Replace <code>&lt;SOURCE_ID&gt;</code> with <code>eap</code>.</p>
-</li>
-<li>
-<p>Replace <code>&lt;TARGET_ID&gt;</code> with <code>eap</code>.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Set the source and target technology versions.</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Replace <code>&lt;SOURCE_VERSION_RANGE&gt;</code> with <code>(4,5)</code>.</p>
-</li>
-<li>
-<p>Replace <code>&lt;TARGET_VERSION_RANGE&gt;</code> with <code>(6,)</code>.</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>See the Apache Maven <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">version range specification</a> for more information.</p>
-</div>
-</li>
-<li>
-<p>Complete the <code>when</code> condition. Because this rule tests for a match in an XML file, <code>xmlfile</code> is used to evaluate the files.</p>
-<div class="paragraph">
-<p>To match on the <code>class-loading</code> element that is a child of <code>jboss-web</code>, use the xpath expression <code>jboss-web/class-loading</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Add the source and target technologies:</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Replace <code>&lt;SOURCE_ID&gt;</code> with <code>eap</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p>Replace <code>&lt;TARGET_ID&gt;</code> with <code>eap</code>.</p>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Set the source and target technology versions.</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Replace <code>&lt;SOURCE_VERSION_RANGE&gt;</code> with <code>(4,5)</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p>Replace <code>&lt;TARGET_VERSION_RANGE&gt;</code> with <code>(6,)</code>.</p>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="paragraph">
+                                <p>See the Apache Maven <a href="http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">version range specification</a> for more information.</p>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Complete the <code>when</code> condition. Because this rule tests for a match in an XML file, <code>xmlfile</code> is used to evaluate the files.</p>
+                            <div class="paragraph">
+                                <p>To match on the <code>class-loading</code> element that is a child of <code>jboss-web</code>, use the xpath expression <code>jboss-web/class-loading</code>.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;when&gt;
     &lt;xmlfile matches="jboss-web/class-loading" /&gt;
 &lt;/when&gt;</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>Complete the <code>perform</code> action for this rule.</p>
-<div class="ulist">
-<ul>
-<li>
-<p>Add a classification with a descriptive title and a level of effort of <code>1</code>.</p>
-</li>
-<li>
-<p>Provide a hint with an informative message and a link to documentation that describes the migration details.</p>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Complete the <code>perform</code> action for this rule.</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p>Add a classification with a descriptive title and a level of effort of <code>1</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p>Provide a hint with an informative message and a link to documentation that describes the migration details.</p>
+                                        <div class="listingblock">
+                                            <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;perform&gt;
     &lt;iteration&gt;
         &lt;classification title="JBoss Web Application Descriptor" effort="1"/&gt;
@@ -808,19 +808,19 @@ otherwise(action)</pre>
         &lt;/hint&gt;
     &lt;/iteration&gt;
 &lt;/perform&gt;</code></pre>
-</div>
-</div>
-</li>
-</ul>
-</div>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>The rule is now complete and should look like the following example.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                            </div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+                <div class="paragraph">
+                    <p>The rule is now complete and should look like the following example.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset id="JBoss5-web-class-loading"
     xmlns="http://windup.jboss.org/schema/jboss-ruleset"
@@ -856,276 +856,276 @@ otherwise(action)</pre>
         &lt;/rule&gt;
      &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-<h4 id="_installing_the_rule" class="discrete">Installing the rule</h4>
-<div class="paragraph">
-<p>An APPCAT rule is installed by placing the rule into the appropriate directory.</p>
-</div>
-<div class="paragraph">
-<p>Copy the <code>JBoss5-web-class-loading.windup.xml</code> file to the <code>&lt;APPCAT_HOME&gt;/rules/</code> directory.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight nowrap"><code>$ cp /home/&lt;USER_NAME&gt;/migration-rules/rules/JBoss5-web-class-loading.windup.xml &lt;APPCAT_HOME&gt;/rules/</code></pre>
-</div>
-</div>
-<h4 id="_testing_the_rule" class="discrete">Testing the rule</h4>
-<div class="paragraph">
-<p>Open a terminal and run the following command, passing the test file as an input argument and a directory for the output report.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli --sourceMode --input /home/&lt;USER_NAME&gt;/migration-rules/data --output /home/&lt;USER_NAME&gt;/migration-rules/reports --target eap:6</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>You should see the following result.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                    </div>
+                </div>
+                <h4 id="_installing_the_rule" class="discrete">Installing the rule</h4>
+                <div class="paragraph">
+                    <p>An APPCAT rule is installed by placing the rule into the appropriate directory.</p>
+                </div>
+                <div class="paragraph">
+                    <p>Copy the <code>JBoss5-web-class-loading.windup.xml</code> file to the <code>&lt;APPCAT_HOME&gt;/rules/</code> directory.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="highlight nowrap"><code>$ cp /home/&lt;USER_NAME&gt;/migration-rules/rules/JBoss5-web-class-loading.windup.xml &lt;APPCAT_HOME&gt;/rules/</code></pre>
+                    </div>
+                </div>
+                <h4 id="_testing_the_rule" class="discrete">Testing the rule</h4>
+                <div class="paragraph">
+                    <p>Open a terminal and run the following command, passing the test file as an input argument and a directory for the output report.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="nowrap">$ &lt;APPCAT_HOME&gt;/bin/appcat --sourceMode --input /home/&lt;USER_NAME&gt;/migration-rules/data --output /home/&lt;USER_NAME&gt;/migration-rules/reports --target eap:6</pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>You should see the following result.</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre class="nowrap">Report created: /home/&lt;USER_NAME&gt;/migration-rules/reports/index.html
               Access it at this URL: file:///home/&lt;USER_NAME&gt;/migration-rules/reports/index.html</pre>
-</div>
-</div>
-<h4 id="_reviewing_the_reports" class="discrete">Reviewing the reports</h4>
-<div class="paragraph">
-<p>Review the report to be sure that it provides the expected results. For a more detailed walkthrough of APPCAT reports, see the <a href="https://access.redhat.com/documentation/en-us/appcat-docs/1.1/html-single/cli_guide#review-reports_cli-guide">Reviewing the reports</a> section of the APPCAT <em>CLI Guide</em>.</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Open <code>/home/&lt;USER_NAME&gt;/migration-rules/reports/index.html</code> in a web browser.</p>
-</li>
-<li>
-<p>Verify that the rule ran successfully.</p>
-<div class="olist loweralpha">
-<ol class="loweralpha" type="a">
-<li>
-<p>From the main landing page, click the <strong>Rule providers execution overview</strong> link to open the Rule Providers Execution Overview.</p>
-</li>
-<li>
-<p>Find the <code>JBoss5-web-class-loading_001</code> rule and verify that its <strong>Status?</strong> is <code>Condition met</code> and its <strong>Result?</strong> is <code>success</code>.</p>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/executed-test-rule.png" alt="Test rule execution">
-</div>
-<div class="title">Figure 1. Test rule execution</div>
-</div>
-</li>
-</ol>
-</div>
-</li>
-<li>
-<p>Verify that the rule matches the test data:</p>
-<div class="olist loweralpha">
-<ol class="loweralpha" type="a">
-<li>
-<p>From the main landing page, click the name of the application or input folder, which is <code>data</code> in this example.</p>
-</li>
-<li>
-<p>Click the <strong>Application Details</strong> report link.</p>
-</li>
-<li>
-<p>Click the <strong>jboss-web.xml</strong> link to view the <strong>Source Report</strong>.</p>
-<div class="paragraph">
-<p>You can see that the <code>&lt;class-loading&gt;</code> line is highlighted, and the hint from the custom rule is shown inline.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/test-rule-details.png" alt="Rule match">
-</div>
-<div class="title">Figure 2. Rule match</div>
-</div>
-<div class="paragraph">
-<p>The top of the file lists the classifications for matching rules. You can use the link icon to view the details for that rule. Notice that in this example, the <code>jboss-web.xml</code> file matched on another rule (<code>JBoss web application descriptor (jboss-web.xml)</code>) that produced <code>1</code> story point. This story point, combined with the <code>1</code> story point from our custom rule, brings the total story points for this file to <code>2</code>.</p>
-</div>
-</li>
-</ol>
-</div>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="review-quickstarts_rules-development-guide-appcat">2.2. Reviewing the Azure Application and Code Assessment Toolkit quickstarts</h3>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit quickstarts provide working examples of how to create custom Java-based rule add-ons and XML rules. You can use them as a starting point for creating your own custom rules.</p>
-</div>
-<div class="paragraph">
-<p>Each quickstart has a <code>README.adoc</code> file that contains instructions for that quickstart.</p>
-</div>
-<div class="paragraph">
-<p>You can download a <code>.zip</code> file of the latest version of the quickstarts. If you prefer to work with the source code, you can fork and clone the <code>windup-quickstarts</code> project repository.</p>
-</div>
-<h4 id="download_quickstart_zip_rules-development-guide-appcat" class="discrete">Downloading the latest quickstart</h4>
-<div class="paragraph">
-<p>You can download the latest release of a quickstart.</p>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Launch a browser and navigate to <a href="https://github.com/windup/windup-quickstarts/releases">https://github.com/windup/windup-quickstarts/releases</a>.</p>
-</li>
-<li>
-<p>Click the latest release to download the <code>.zip</code> file to your local file system.</p>
-</li>
-<li>
-<p>Extract the archive files to a local directory.</p>
-<div class="paragraph">
-<p>You can review the quickstart <code>README.adoc</code> file.</p>
-</div>
-</li>
-</ol>
-</div>
-<h4 id="use-quickstart-github-project_rules-development-guide-appcat" class="discrete">Forking and cloning the quickstart GitHub project</h4>
-<div class="paragraph">
-<p>You can fork and clone the Quickstart Github project on your local machine.</p>
-</div>
-<div class="ulist">
-<div class="title">Prerequisites</div>
-<ul>
-<li>
-<p>You must have <a href="http://git-scm.com/"><code>git</code></a> client installed.</p>
-</li>
-</ul>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Click <strong>Fork</strong> on the <a href="https://github.com/windup/windup-quickstarts/">Azure Application and Code Assessment Toolkit quickstart</a> GitHub page to create the project in your own Git. The forked GitHub repository URL should look like this: <code>https://github.com/&lt;YOUR_USER_NAME&gt;/windup-quickstarts.git</code>.</p>
-</li>
-<li>
-<p>Clone the Azure Application and Code Assessment Toolkit quickstart repository to your local file system:</p>
-<div class="listingblock">
-<div class="content">
-<pre>$ git clone https://github.com/&lt;YOUR_USER_NAME&gt;/windup-quickstarts.git</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>This creates a <code>windup-quickstarts</code> directory on your local file system.</p>
-</div>
-</li>
-<li>
-<p>Navigate to the newly created directory:</p>
-<div class="listingblock">
-<div class="content">
-<pre>$ cd windup-quickstarts/</pre>
-</div>
-</div>
-</li>
-<li>
-<p>To retrieve the latest code updates, add the remote <code>upstream</code> repository so that you can fetch changes to the original forked repository:</p>
-<div class="listingblock">
-<div class="content">
-<pre>$ git remote add upstream https://github.com/windup/windup-quickstarts.git</pre>
-</div>
-</div>
-</li>
-<li>
-<p>Download the latest files from the <code>upstream</code> repository:</p>
-<div class="listingblock">
-<div class="content">
-<pre>$ git fetch upstream</pre>
-</div>
-</div>
-</li>
-</ol>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_creating_xml_rules">3. Creating XML rules</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="xml-rule-syntax_rules-development-guide-appcat">3.1. XML rule structure</h3>
-<div class="paragraph">
-<p>This section describes the basic structure of XML rules. All XML rules are defined as elements within rulesets. For more details, see the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">APPCAT XML rule schema</a>.</p>
-</div>
-<div class="sect3">
-<h4 id="_rulesets">3.1.1. Rulesets</h4>
-<div class="paragraph">
-<p>A ruleset is a group of one or more rules that targets a specific area of migration. This is the basic structure of the <code>&lt;ruleset&gt;</code> element.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>&lt;ruleset id="&lt;UNIQUE_RULESET_ID&gt;"&gt;</strong>: Defines this as an APPCAT ruleset and gives it a unique ruleset ID.</p>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>&lt;metadata&gt;</strong>: The metadata about the ruleset.</p>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>&lt;description&gt;</strong>: The description of the ruleset.</p>
-</li>
-<li>
-<p><strong>&lt;dependencies/&gt;</strong>: The rule add-ons required by this ruleset.</p>
-</li>
-<li>
-<p><strong> &lt;sourceTechnology/&gt;</strong>: The source technology.</p>
-</li>
-<li>
-<p><strong> &lt;targetTechnology/&gt;</strong>: The target technology.</p>
-</li>
-<li>
-<p><strong> &lt;overrideRules/&gt;</strong>: Setting to <code>true</code> indicates that rules in this ruleset override rules with the same ID from the core ruleset distributed with APPCAT. Both the ruleset id and the rule id must match a rule within the core ruleset or the rule will be ignored. This is <code>false</code> by default.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p><strong>&lt;rules&gt;</strong>: A set of individual rules.</p>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>&lt;rule id="&lt;UNIQUE_RULE_ID&gt;"&gt;</strong>: Defines the rule and gives it a unique ID. It is recommended to include the ruleset ID as part of the rule ID, for example, <code>&lt;UNIQUE_RULESET_ID_UNIQUE_RULE_ID&gt;</code>. One or more rules can be defined for a ruleset.</p>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>&lt;when&gt;</strong>: The conditions to match on.</p>
-</li>
-<li>
-<p><strong>&lt;perform&gt;</strong>: The action to be performed when the rule condition is matched.</p>
-</li>
-<li>
-<p><strong>&lt;otherwise&gt;</strong>: The action to be performed when the rule condition is not matched. This element takes the same child elements as the <code>&lt;perform&gt;</code> element.</p>
-</li>
-<li>
-<p><strong>&lt;where&gt;</strong>: A string pattern defined as a parameter, which can be used elsewhere in the rule definition.</p>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p><strong>&lt;file-mapping/&gt;</strong>: Maps an extension to a graph type.</p>
-</li>
-<li>
-<p><strong>&lt;package-mapping/&gt;</strong>: Maps from a package pattern (regular expression) to an organization name.</p>
-</li>
-</ul>
-</div>
-</li>
-</ul>
-</div>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_predefined_rules">3.1.2. Predefined rules</h4>
-<div class="paragraph">
-<p>APPCAT provides predefined rules for common migration requirements. These core APPCAT rules are located in the APPCAT installation at <code>&lt;APPCAT_HOME&gt;/rules/migration-core/</code>.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a core APPCAT rule that matches on a proprietary utility class.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                    </div>
+                </div>
+                <h4 id="_reviewing_the_reports" class="discrete">Reviewing the reports</h4>
+                <div class="paragraph">
+                    <p>Review the report to be sure that it provides the expected results. For a more detailed walkthrough of APPCAT reports, see the <a href="https://access.redhat.com/documentation/en-us/appcat-docs/1.1/html-single/cli_guide#review-reports_cli-guide">Reviewing the reports</a> section of the APPCAT <em>CLI Guide</em>.</p>
+                </div>
+                <div class="olist arabic">
+                    <ol class="arabic">
+                        <li>
+                            <p>Open <code>/home/&lt;USER_NAME&gt;/migration-rules/reports/index.html</code> in a web browser.</p>
+                        </li>
+                        <li>
+                            <p>Verify that the rule ran successfully.</p>
+                            <div class="olist loweralpha">
+                                <ol class="loweralpha" type="a">
+                                    <li>
+                                        <p>From the main landing page, click the <strong>Rule providers execution overview</strong> link to open the Rule Providers Execution Overview.</p>
+                                    </li>
+                                    <li>
+                                        <p>Find the <code>JBoss5-web-class-loading_001</code> rule and verify that its <strong>Status?</strong> is <code>Condition met</code> and its <strong>Result?</strong> is <code>success</code>.</p>
+                                        <div class="imageblock">
+                                            <div class="content">
+                                                <img src="topics/images/executed-test-rule.png" alt="Test rule execution">
+                                            </div>
+                                            <div class="title">Figure 1. Test rule execution</div>
+                                        </div>
+                                    </li>
+                                </ol>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Verify that the rule matches the test data:</p>
+                            <div class="olist loweralpha">
+                                <ol class="loweralpha" type="a">
+                                    <li>
+                                        <p>From the main landing page, click the name of the application or input folder, which is <code>data</code> in this example.</p>
+                                    </li>
+                                    <li>
+                                        <p>Click the <strong>Application Details</strong> report link.</p>
+                                    </li>
+                                    <li>
+                                        <p>Click the <strong>jboss-web.xml</strong> link to view the <strong>Source Report</strong>.</p>
+                                        <div class="paragraph">
+                                            <p>You can see that the <code>&lt;class-loading&gt;</code> line is highlighted, and the hint from the custom rule is shown inline.</p>
+                                        </div>
+                                        <div class="imageblock">
+                                            <div class="content">
+                                                <img src="topics/images/test-rule-details.png" alt="Rule match">
+                                            </div>
+                                            <div class="title">Figure 2. Rule match</div>
+                                        </div>
+                                        <div class="paragraph">
+                                            <p>The top of the file lists the classifications for matching rules. You can use the link icon to view the details for that rule. Notice that in this example, the <code>jboss-web.xml</code> file matched on another rule (<code>JBoss web application descriptor (jboss-web.xml)</code>) that produced <code>1</code> story point. This story point, combined with the <code>1</code> story point from our custom rule, brings the total story points for this file to <code>2</code>.</p>
+                                        </div>
+                                    </li>
+                                </ol>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="review-quickstarts_rules-development-guide-appcat">2.2. Reviewing the Azure Migrate application and code assessment for Java quickstarts</h3>
+                <div class="paragraph">
+                    <p>The Azure Migrate application and code assessment for Java quickstarts provide working examples of how to create custom Java-based rule add-ons and XML rules. You can use them as a starting point for creating your own custom rules.</p>
+                </div>
+                <div class="paragraph">
+                    <p>Each quickstart has a <code>README.adoc</code> file that contains instructions for that quickstart.</p>
+                </div>
+                <div class="paragraph">
+                    <p>You can download a <code>.zip</code> file of the latest version of the quickstarts. If you prefer to work with the source code, you can fork and clone the <code>windup-quickstarts</code> project repository.</p>
+                </div>
+                <h4 id="download_quickstart_zip_rules-development-guide-appcat" class="discrete">Downloading the latest quickstart</h4>
+                <div class="paragraph">
+                    <p>You can download the latest release of a quickstart.</p>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>Launch a browser and navigate to <a href="https://github.com/windup/windup-quickstarts/releases">https://github.com/windup/windup-quickstarts/releases</a>.</p>
+                        </li>
+                        <li>
+                            <p>Click the latest release to download the <code>.zip</code> file to your local file system.</p>
+                        </li>
+                        <li>
+                            <p>Extract the archive files to a local directory.</p>
+                            <div class="paragraph">
+                                <p>You can review the quickstart <code>README.adoc</code> file.</p>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+                <h4 id="use-quickstart-github-project_rules-development-guide-appcat" class="discrete">Forking and cloning the quickstart GitHub project</h4>
+                <div class="paragraph">
+                    <p>You can fork and clone the Quickstart Github project on your local machine.</p>
+                </div>
+                <div class="ulist">
+                    <div class="title">Prerequisites</div>
+                    <ul>
+                        <li>
+                            <p>You must have <a href="http://git-scm.com/"><code>git</code></a> client installed.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>Click <strong>Fork</strong> on the <a href="https://github.com/windup/windup-quickstarts/">Azure Migrate application and code assessment for Java quickstart</a> GitHub page to create the project in your own Git. The forked GitHub repository URL should look like this: <code>https://github.com/&lt;YOUR_USER_NAME&gt;/windup-quickstarts.git</code>.</p>
+                        </li>
+                        <li>
+                            <p>Clone the Azure Migrate application and code assessment for Java quickstart repository to your local file system:</p>
+                            <div class="listingblock">
+                                <div class="content">
+                                    <pre>$ git clone https://github.com/&lt;YOUR_USER_NAME&gt;/windup-quickstarts.git</pre>
+                                </div>
+                            </div>
+                            <div class="paragraph">
+                                <p>This creates a <code>windup-quickstarts</code> directory on your local file system.</p>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Navigate to the newly created directory:</p>
+                            <div class="listingblock">
+                                <div class="content">
+                                    <pre>$ cd windup-quickstarts/</pre>
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>To retrieve the latest code updates, add the remote <code>upstream</code> repository so that you can fetch changes to the original forked repository:</p>
+                            <div class="listingblock">
+                                <div class="content">
+                                    <pre>$ git remote add upstream https://github.com/windup/windup-quickstarts.git</pre>
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Download the latest files from the <code>upstream</code> repository:</p>
+                            <div class="listingblock">
+                                <div class="content">
+                                    <pre>$ git fetch upstream</pre>
+                                </div>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="_creating_xml_rules">3. Creating XML rules</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="xml-rule-syntax_rules-development-guide-appcat">3.1. XML rule structure</h3>
+                <div class="paragraph">
+                    <p>This section describes the basic structure of XML rules. All XML rules are defined as elements within rulesets. For more details, see the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">APPCAT XML rule schema</a>.</p>
+                </div>
+                <div class="sect3">
+                    <h4 id="_rulesets">3.1.1. Rulesets</h4>
+                    <div class="paragraph">
+                        <p>A ruleset is a group of one or more rules that targets a specific area of migration. This is the basic structure of the <code>&lt;ruleset&gt;</code> element.</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p><strong>&lt;ruleset id="&lt;UNIQUE_RULESET_ID&gt;"&gt;</strong>: Defines this as an APPCAT ruleset and gives it a unique ruleset ID.</p>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p><strong>&lt;metadata&gt;</strong>: The metadata about the ruleset.</p>
+                                            <div class="ulist">
+                                                <ul>
+                                                    <li>
+                                                        <p><strong>&lt;description&gt;</strong>: The description of the ruleset.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong>&lt;dependencies/&gt;</strong>: The rule add-ons required by this ruleset.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong> &lt;sourceTechnology/&gt;</strong>: The source technology.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong> &lt;targetTechnology/&gt;</strong>: The target technology.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong> &lt;overrideRules/&gt;</strong>: Setting to <code>true</code> indicates that rules in this ruleset override rules with the same ID from the core ruleset distributed with APPCAT. Both the ruleset id and the rule id must match a rule within the core ruleset or the rule will be ignored. This is <code>false</code> by default.</p>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </li>
+                                        <li>
+                                            <p><strong>&lt;rules&gt;</strong>: A set of individual rules.</p>
+                                            <div class="ulist">
+                                                <ul>
+                                                    <li>
+                                                        <p><strong>&lt;rule id="&lt;UNIQUE_RULE_ID&gt;"&gt;</strong>: Defines the rule and gives it a unique ID. It is recommended to include the ruleset ID as part of the rule ID, for example, <code>&lt;UNIQUE_RULESET_ID_UNIQUE_RULE_ID&gt;</code>. One or more rules can be defined for a ruleset.</p>
+                                                        <div class="ulist">
+                                                            <ul>
+                                                                <li>
+                                                                    <p><strong>&lt;when&gt;</strong>: The conditions to match on.</p>
+                                                                </li>
+                                                                <li>
+                                                                    <p><strong>&lt;perform&gt;</strong>: The action to be performed when the rule condition is matched.</p>
+                                                                </li>
+                                                                <li>
+                                                                    <p><strong>&lt;otherwise&gt;</strong>: The action to be performed when the rule condition is not matched. This element takes the same child elements as the <code>&lt;perform&gt;</code> element.</p>
+                                                                </li>
+                                                                <li>
+                                                                    <p><strong>&lt;where&gt;</strong>: A string pattern defined as a parameter, which can be used elsewhere in the rule definition.</p>
+                                                                </li>
+                                                            </ul>
+                                                        </div>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong>&lt;file-mapping/&gt;</strong>: Maps an extension to a graph type.</p>
+                                                    </li>
+                                                    <li>
+                                                        <p><strong>&lt;package-mapping/&gt;</strong>: Maps from a package pattern (regular expression) to an organization name.</p>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_predefined_rules">3.1.2. Predefined rules</h4>
+                    <div class="paragraph">
+                        <p>APPCAT provides predefined rules for common migration requirements. These core APPCAT rules are located in the APPCAT installation at <code>&lt;APPCAT_HOME&gt;/rules/migration-core/</code>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The following is an example of a core APPCAT rule that matches on a proprietary utility class.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="weblogic" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"&gt;
@@ -1160,46 +1160,46 @@ otherwise(action)</pre>
         ...
     &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="create-basic-xml-rule_rules-development-guide-appcat">3.2. Creating a basic XML rule</h3>
-<div class="paragraph">
-<p>This section describes how to create an APPCAT XML rule. This assumes that you already have APPCAT installed. See the APPCAT <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a> for installation instructions.</p>
-</div>
-<div class="sect3">
-<h4 id="_creating_a_basic_xml_rule_template">3.2.1. Creating a basic XML rule template</h4>
-<div class="paragraph">
-<p>APPCAT XML rules consist of <em>conditions</em> and <em>actions</em> and use the following rule pattern:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="create-basic-xml-rule_rules-development-guide-appcat">3.2. Creating a basic XML rule</h3>
+                <div class="paragraph">
+                    <p>This section describes how to create an APPCAT XML rule. This assumes that you already have APPCAT installed. See the APPCAT <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a> for installation instructions.</p>
+                </div>
+                <div class="sect3">
+                    <h4 id="_creating_a_basic_xml_rule_template">3.2.1. Creating a basic XML rule template</h4>
+                    <div class="paragraph">
+                        <p>APPCAT XML rules consist of <em>conditions</em> and <em>actions</em> and use the following rule pattern:</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
 <pre class="highlight"><code class="language-terminal" data-lang="terminal">when(condition)
   perform(action)
 otherwise(action)</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>Create a file with the following contents, which is the basic syntax for XML rules.</p>
-</div>
-<div class="admonitionblock important">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Important</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>The XML file name must include the <code>.windup.xml</code> extension. Otherwise, APPCAT does not evaluate the new rule.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<div class="listingblock">
-<div class="content">
+                        </div>
+                    </div>
+                    <div class="paragraph">
+                        <p>Create a file with the following contents, which is the basic syntax for XML rules.</p>
+                    </div>
+                    <div class="admonitionblock important">
+                        <table>
+                            <tr>
+                                <td class="icon">
+                                    <div class="title">Important</div>
+                                </td>
+                                <td class="content">
+                                    <div class="paragraph">
+                                        <p>The XML file name must include the <code>.windup.xml</code> extension. Otherwise, APPCAT does not evaluate the new rule.</p>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset id="unique-ruleset-id"
   xmlns="http://windup.jboss.org/schema/jboss-ruleset"
@@ -1224,17 +1224,17 @@ otherwise(action)</code></pre>
     &lt;/rule&gt;
   &lt;rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_creating_the_ruleset_metadata">3.2.2. Creating the ruleset metadata</h4>
-<div class="paragraph">
-<p>The XML ruleset <code>metadata</code> element provides additional information about the ruleset such as a description, the source and target technologies, and add-on dependencies. The metadata also allows for specification of tags, which allow you to provide additional information about a ruleset.</p>
-</div>
-<div class="listingblock">
-<div class="title"><code>&lt;metadata&gt;</code> example</div>
-<div class="content">
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_creating_the_ruleset_metadata">3.2.2. Creating the ruleset metadata</h4>
+                    <div class="paragraph">
+                        <p>The XML ruleset <code>metadata</code> element provides additional information about the ruleset such as a description, the source and target technologies, and add-on dependencies. The metadata also allows for specification of tags, which allow you to provide additional information about a ruleset.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="title"><code>&lt;metadata&gt;</code> example</div>
+                        <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;ruleset id="unique-ruleset-id"
   xmlns="http://windup.jboss.org/schema/jboss-ruleset"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -1260,189 +1260,189 @@ otherwise(action)</code></pre>
     ...
   &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_creating_a_rule">3.2.3. Creating a rule</h4>
-<div class="paragraph">
-<p>Individual rules are contained within the <code>&lt;rules&gt;</code> element. They comprise one or more <code>when</code> conditions and perform actions.</p>
-</div>
-<div class="paragraph">
-<p>See the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">XML rule schema</a> for valid rule syntax.</p>
-</div>
-<div class="sect4">
-<h5 id="create-when-condition_rules-development-guide-appcat">Creating a <code>&lt;when&gt;</code> condition</h5>
-<div class="paragraph">
-<p>The XML rule <code>&lt;when&gt;</code> element tests for a condition. The following is a list of valid <code>&lt;when&gt;</code> conditions.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;and&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>and</em> operator.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;filecontent&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Find strings or text within files, for example, properties files.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;file-mapping&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Define file names to internal stored File model.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;javaclass&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Test for a match in a Java class.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;javaclass-ignore&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Exclude javaclass which you would like to ignore in processing discovery.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;not&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>not</em> operator.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;or&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>or</em> operator.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;package-mapping&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Define package names to organization or libraries.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;project&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Test for project characteristics, such as dependencies.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;true&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Always match.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xmlfile&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Test for a match in an XML file.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p>The specific syntax is dependent on whether you are creating a rule to evaluate Java class, an XML file, a project, or file content.</p>
-</div>
-</div>
-<div class="sect4">
-<h5 id="create-perform-action_rules-development-guide-appcat">Creating a <code>&lt;perform&gt;</code> action</h5>
-<div class="paragraph">
-<p>The XML rule <code>&lt;perform&gt;</code> element performs the action when the condition is met. Operations allowed in this section of the rule include the classification of application resources, in-line hints for migration steps, links to migration information, and project line item reporting. The following is a list of valid <code>&lt;perform&gt;</code> actions.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;classification&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This operation adds metadata that you want to apply to the entire file. For example, if the Java Class is a JMS Message Listener, you can add a Classification with the title "JMS Message Listener" that includes information that applies to the entire file. You can also set an effort level for the entire file.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;hint&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This operation adds metadata to a line within the file. This provides a hint or inline information about how to migrate a section of code.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;iteration&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This specifies to iterate over an implicit or explicit variable defined within the rule.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;lineitem&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This provides a high-level message that is displayed in the application overview page.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This provides an HTML link to additional information or documentation about the migration task.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xslt&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This specifies how to transform an XML file.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_xml_rule_syntax">3.3. XML rule syntax</h3>
-<div class="sect3">
-<h4 id="xml-rule-when-syntax_rules-development-guide-appcat">3.3.1. <code>&lt;when&gt;</code> syntax</h4>
-<div class="paragraph">
-<p>Conditions allowed in the <code>when</code> portion of a rule must extend <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/operation/GraphOperation.html">GraphOperation</a> and currently include evaluation of Java classes, XML files, projects, and file content. Because XML rules are modeled after the Java-based rule add-ons, links to JavaDocs for the related Java classes are provided for a better understanding of how they behave.</p>
-</div>
-<div class="paragraph">
-<p>The complete XML rule schema is located here: <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd" class="bare">http://windup.jboss.org/schema/windup-jboss-ruleset.xsd</a>.</p>
-</div>
-<div class="paragraph">
-<p>The following sections describe the more common XML <code>when</code> rule conditions.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>&lt;javaclass&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;xmlfile&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;project&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;filecontent&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;file&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;has-hint&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;has-classification&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;graph-query&gt; condition syntax</p>
-</li>
-<li>
-<p>&lt;dependency&gt; condition syntax</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>By default, if more than one <code>when</code> rule condition is provided, then all conditions must be met for the rule to match.</p>
-</div>
-<div class="sect4">
-<h5 id="javaclass-syntax_rules-development-guide-appcat">&lt;javaclass&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;javaclass&gt;</code> element to find imports, methods, variable declarations, annotations, class implementations, and other items related to Java classes. For a better understanding of the <code>&lt;javaclass&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/java/condition/JavaClass.html">JavaClass</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that tests for WebLogic-specific Apache XML packages:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_creating_a_rule">3.2.3. Creating a rule</h4>
+                    <div class="paragraph">
+                        <p>Individual rules are contained within the <code>&lt;rules&gt;</code> element. They comprise one or more <code>when</code> conditions and perform actions.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>See the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">XML rule schema</a> for valid rule syntax.</p>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="create-when-condition_rules-development-guide-appcat">Creating a <code>&lt;when&gt;</code> condition</h5>
+                        <div class="paragraph">
+                            <p>The XML rule <code>&lt;when&gt;</code> element tests for a condition. The following is a list of valid <code>&lt;when&gt;</code> conditions.</p>
+                        </div>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 80%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Element</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;and&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>and</em> operator.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;filecontent&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Find strings or text within files, for example, properties files.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;file-mapping&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Define file names to internal stored File model.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;javaclass&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Test for a match in a Java class.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;javaclass-ignore&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Exclude javaclass which you would like to ignore in processing discovery.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;not&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>not</em> operator.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;or&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The standard logical <em>or</em> operator.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;package-mapping&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Define package names to organization or libraries.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;project&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Test for project characteristics, such as dependencies.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;true&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Always match.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xmlfile&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">Test for a match in an XML file.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        <div class="paragraph">
+                            <p>The specific syntax is dependent on whether you are creating a rule to evaluate Java class, an XML file, a project, or file content.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="create-perform-action_rules-development-guide-appcat">Creating a <code>&lt;perform&gt;</code> action</h5>
+                        <div class="paragraph">
+                            <p>The XML rule <code>&lt;perform&gt;</code> element performs the action when the condition is met. Operations allowed in this section of the rule include the classification of application resources, in-line hints for migration steps, links to migration information, and project line item reporting. The following is a list of valid <code>&lt;perform&gt;</code> actions.</p>
+                        </div>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 80%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Element</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;classification&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This operation adds metadata that you want to apply to the entire file. For example, if the Java Class is a JMS Message Listener, you can add a Classification with the title "JMS Message Listener" that includes information that applies to the entire file. You can also set an effort level for the entire file.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;hint&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This operation adds metadata to a line within the file. This provides a hint or inline information about how to migrate a section of code.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;iteration&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This specifies to iterate over an implicit or explicit variable defined within the rule.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;lineitem&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This provides a high-level message that is displayed in the application overview page.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This provides an HTML link to additional information or documentation about the migration task.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xslt&gt;</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">This specifies how to transform an XML file.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_xml_rule_syntax">3.3. XML rule syntax</h3>
+                <div class="sect3">
+                    <h4 id="xml-rule-when-syntax_rules-development-guide-appcat">3.3.1. <code>&lt;when&gt;</code> syntax</h4>
+                    <div class="paragraph">
+                        <p>Conditions allowed in the <code>when</code> portion of a rule must extend <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/operation/GraphOperation.html">GraphOperation</a> and currently include evaluation of Java classes, XML files, projects, and file content. Because XML rules are modeled after the Java-based rule add-ons, links to JavaDocs for the related Java classes are provided for a better understanding of how they behave.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The complete XML rule schema is located here: <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd" class="bare">http://windup.jboss.org/schema/windup-jboss-ruleset.xsd</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The following sections describe the more common XML <code>when</code> rule conditions.</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>&lt;javaclass&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;xmlfile&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;project&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;filecontent&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;file&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;has-hint&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;has-classification&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;graph-query&gt; condition syntax</p>
+                            </li>
+                            <li>
+                                <p>&lt;dependency&gt; condition syntax</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p>By default, if more than one <code>when</code> rule condition is provided, then all conditions must be met for the rule to match.</p>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="javaclass-syntax_rules-development-guide-appcat">&lt;javaclass&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;javaclass&gt;</code> element to find imports, methods, variable declarations, annotations, class implementations, and other items related to Java classes. For a better understanding of the <code>&lt;javaclass&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/java/condition/JavaClass.html">JavaClass</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that tests for WebLogic-specific Apache XML packages:</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="weblogic-03000"&gt;
     &lt;when&gt;
         &lt;javaclass references="weblogic.apache.xml.{*}" /&gt;
@@ -1456,205 +1456,205 @@ otherwise(action)</code></pre>
         &lt;/hint&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_javaclass_element">Construct a &lt;javaclass&gt; element</h6>
-<div class="sect6">
-<h7 id="_javaclass_element_attributes">&lt;javaclass&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">references</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">CLASS_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The package or class name to match on. Wildcard characters can be used. This attribute is required.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-For performance reasons, you should not start the reference with wildcard characters. For example, use <code>weblogic.apache.xml.{*}</code> instead of <code>{web}.apache.xml.{*}</code>.
-</td>
-</tr>
-</table>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">references="weblogic.apache.xml.{*}"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">matchesSource</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>An exact regex to match. This is useful to distinguish hard-coded strings. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">matchesSource="log4j.logger"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">as="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">from="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PATH_FILTER</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Filter input files matching this regex (regular expression) naming pattern. Wildcard characters can be used.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">in="{*}File1"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect6">
-<h7 id="_javaclass_child_elements">&lt;javaclass&gt; child elements</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;location&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The location where the reference was found in a Java class. Location can refer to annotations, field and variable declarations, imports, and methods. For the complete list of valid values, see the JavaDoc for <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/ast/java/data/TypeReferenceLocation.html">TypeReferenceLocation</a>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;location&gt;IMPORT&lt;/location&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-literal&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Match on literal values inside of annotations.</p>
-</div>
-<div class="paragraph">
-<p>The following example matches on <code>@MyAnnotation(myvalue="test")</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_javaclass_element">Construct a &lt;javaclass&gt; element</h6>
+                            <div class="sect6">
+                                <h7 id="_javaclass_element_attributes">&lt;javaclass&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">references</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">CLASS_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>The package or class name to match on. Wildcard characters can be used. This attribute is required.</p>
+                                        </div>
+                                            <div class="admonitionblock note">
+                                                <table>
+                                                    <tr>
+                                                        <td class="icon">
+                                                            <div class="title">Note</div>
+                                                        </td>
+                                                        <td class="content">
+                                                            For performance reasons, you should not start the reference with wildcard characters. For example, use <code>weblogic.apache.xml.{*}</code> instead of <code>{web}.apache.xml.{*}</code>.
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">references="weblogic.apache.xml.{*}"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">matchesSource</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>An exact regex to match. This is useful to distinguish hard-coded strings. This attribute is required.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">matchesSource="log4j.logger"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">as="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">from="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">PATH_FILTER</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Filter input files matching this regex (regular expression) naming pattern. Wildcard characters can be used.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">in="{*}File1"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_javaclass_child_elements">&lt;javaclass&gt; child elements</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 80%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Child Element</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;location&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>The location where the reference was found in a Java class. Location can refer to annotations, field and variable declarations, imports, and methods. For the complete list of valid values, see the JavaDoc for <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/ast/java/data/TypeReferenceLocation.html">TypeReferenceLocation</a>.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;location&gt;IMPORT&lt;/location&gt;</code></pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-literal&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Match on literal values inside of annotations.</p>
+                                        </div>
+                                            <div class="paragraph">
+                                                <p>The following example matches on <code>@MyAnnotation(myvalue="test")</code>.</p>
+                                            </div>
+                                            <div class="listingblock">
+                                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;javaclass references="org.package.MyAnnotation"&gt;
     &lt;location&gt;ANNOTATION&lt;/location&gt;
     &lt;annotation-literal name="myvalue" pattern="test"/&gt;
 &lt;/javaclass&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>Note that in this case, the <code>&lt;javaclass&gt;</code> refers to an annotation (<code>@MyAnnotation</code>), so the top-level annotation filter, <code>&lt;annotation-literal&gt;</code> must specify the <code>name</code> attribute. If the <code>&lt;javaclass&gt;</code> referred to a class that is annotated, then the top-level annotation filter used would be <code>&lt;annotation-type&gt;</code>.</p>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-type&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Match on a particular annotation type. You can supply subconditions to be matched against the annotation elements.</p>
-</div>
-<div class="paragraph">
-<p>The below example would match on a <code>Calendar</code> field declaration annotated with <code>@MyAnnotation(myvalue="test")</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                                </div>
+                                            </div>
+                                            <div class="paragraph">
+                                                <p>Note that in this case, the <code>&lt;javaclass&gt;</code> refers to an annotation (<code>@MyAnnotation</code>), so the top-level annotation filter, <code>&lt;annotation-literal&gt;</code> must specify the <code>name</code> attribute. If the <code>&lt;javaclass&gt;</code> referred to a class that is annotated, then the top-level annotation filter used would be <code>&lt;annotation-type&gt;</code>.</p>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-type&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Match on a particular annotation type. You can supply subconditions to be matched against the annotation elements.</p>
+                                        </div>
+                                            <div class="paragraph">
+                                                <p>The below example would match on a <code>Calendar</code> field declaration annotated with <code>@MyAnnotation(myvalue="test")</code>.</p>
+                                            </div>
+                                            <div class="listingblock">
+                                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;javaclass references="java.util.Calendar"&gt;
     &lt;location&gt;FIELD_DECLARATION&lt;/location&gt;
     &lt;annotation-type pattern="org.package.MyAnnotation"&gt;
         &lt;annotation-literal name="myvalue" pattern="test"/&gt;
     &lt;/annotation-type&gt;
 &lt;/javaclass&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-list&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Match on an item in an array within an annotation. If an array index is not specified, the condition will be matched if it applies to any item in the array. You can supply subconditions to be matched against this element.</p>
-</div>
-<div class="paragraph">
-<p>The below example would match on <code>@MyAnnotation(mylist={"one","two"})</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;annotation-list&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Match on an item in an array within an annotation. If an array index is not specified, the condition will be matched if it applies to any item in the array. You can supply subconditions to be matched against this element.</p>
+                                        </div>
+                                            <div class="paragraph">
+                                                <p>The below example would match on <code>@MyAnnotation(mylist={"one","two"})</code>.</p>
+                                            </div>
+                                            <div class="listingblock">
+                                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;javaclass references="org.package.MyAnnotation" &gt;
     &lt;location&gt;ANNOTATION&lt;/location&gt;
     &lt;annotation-list name="mylist"&gt;
         &lt;annotation-literal pattern="two"/&gt;
     &lt;/annotation-list&gt;
 &lt;/javaclass&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>Note that in this case, the <code>&lt;javaclass&gt;</code> refers to an annotation (<code>@MyAnnotation</code>), so the top-level annotation filter, <code>&lt;annotation-list&gt;</code> must specify the <code>name</code> attribute. If the <code>&lt;javaclass&gt;</code> referred to a class that is annotated, then the top-level annotation filter used would be <code>&lt;annotation-type&gt;</code>.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="xmlfile-syntax_rules-development-guide-appcat">&lt;xmlfile&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_2">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;xmlfile&gt;</code> element to find information in XML files. For a better understanding of the <code>&lt;xmlfile&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/xml/condition/XmlFile.html">XmlFile</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that tests for an XML file:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                                </div>
+                                            </div>
+                                            <div class="paragraph">
+                                                <p>Note that in this case, the <code>&lt;javaclass&gt;</code> refers to an annotation (<code>@MyAnnotation</code>), so the top-level annotation filter, <code>&lt;annotation-list&gt;</code> must specify the <code>name</code> attribute. If the <code>&lt;javaclass&gt;</code> referred to a class that is annotated, then the top-level annotation filter used would be <code>&lt;annotation-type&gt;</code>.</p>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="xmlfile-syntax_rules-development-guide-appcat">&lt;xmlfile&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_2">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;xmlfile&gt;</code> element to find information in XML files. For a better understanding of the <code>&lt;xmlfile&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/xml/condition/XmlFile.html">XmlFile</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that tests for an XML file:</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre>&lt;rule id="&lt;UNIQUE_RULE_ID&gt;"&gt;
     &lt;when&gt;
         &lt;xmlfile matches="/w:web-app/w:resource-ref/w:res-auth[text() = 'Container']"&gt;
@@ -1669,180 +1669,180 @@ For performance reasons, you should not start the reference with wildcard charac
               template="/exampleconversion.xsl"/&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_an_xmlfile_element">Construct an &lt;xmlfile&gt; element</h6>
-<div class="sect6">
-<h7 id="_xmlfile_element_attributes">&lt;xmlfile&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">matches</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">XPATH</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Match on an XML file condition.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">matches="/w:web-app/w:resource-ref/w:res-auth[text() = 'Container']"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">xpathResultMatch</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">XPATH_RESULT_STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Return results that match the given regex.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_an_xmlfile_element">Construct an &lt;xmlfile&gt; element</h6>
+                            <div class="sect6">
+                                <h7 id="_xmlfile_element_attributes">&lt;xmlfile&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">matches</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">XPATH</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Match on an XML file condition.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">matches="/w:web-app/w:resource-ref/w:res-auth[text() = 'Container']"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">xpathResultMatch</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">XPATH_RESULT_STRING</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Return results that match the given regex.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
 <pre class="nowrap">&lt;xmlfile matches="//foo/text()"
   xpathResultMatch="Text from foo."/&gt;</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">as="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PATH_FILTER</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Used to filter input files matching this regex (regular expression) naming pattern. Wildcard characters can be used.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">in="{*}File1"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">from="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">public-id</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PUBLIC_ID</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The DTD public-id regex.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">public-id="public"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect6">
-<h7 id="_xmlfile_matches_custom_functions">&lt;xmlfile&gt; <code>matches</code> custom functions</h7>
-<div class="paragraph">
-<p>The <code>matches</code> attribute may use several built-in custom XPath functions,
-which may have useful side effects, like setting the matched value on the rule variables stack.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Function</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>windup:matches()</code></p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Match a XPath expression against a string, possibly containing APPCAT parameterization placeholders.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">matches="windup:matches(//foo/@class, '{javaclassname}')"</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>This will match all <code>&lt;foo/&gt;</code> elements with a <code>class</code> attribute and store their value into <code>javaclassname</code> parameter for each iteration.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect6">
-<h7 id="_xmlfile_child_elements">&lt;xmlfile&gt; child elements</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;namespace&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The namespace referenced in XML files. This element contains two optional attributes: The <code>prefix</code> and the <code>uri</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;namespace prefix="abc" uri="http://maven.apache.org/POM/4.0.0"/&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="project-syntax_rules-development-guide-appcat">&lt;project&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_3">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;project&gt;</code> element to query the Maven POM file for the project characteristics. For a better understanding of the <code>&lt;project&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/project/condition/Project.html">Project</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that checks for a JUnit dependency version between 2.0.0.Final and 2.2.0.Final.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">as="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">PATH_FILTER</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Used to filter input files matching this regex (regular expression) naming pattern. Wildcard characters can be used.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">in="{*}File1"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">from="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">public-id</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">PUBLIC_ID</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>The DTD public-id regex.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">public-id="public"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_xmlfile_matches_custom_functions">&lt;xmlfile&gt; <code>matches</code> custom functions</h7>
+                                <div class="paragraph">
+                                    <p>The <code>matches</code> attribute may use several built-in custom XPath functions,
+                                        which may have useful side effects, like setting the matched value on the rule variables stack.</p>
+                                </div>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 50%;">
+                                        <col style="width: 50%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Function</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock"><code>windup:matches()</code></p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Match a XPath expression against a string, possibly containing APPCAT parameterization placeholders.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">matches="windup:matches(//foo/@class, '{javaclassname}')"</pre>
+                                                </div>
+                                            </div>
+                                            <div class="paragraph">
+                                                <p>This will match all <code>&lt;foo/&gt;</code> elements with a <code>class</code> attribute and store their value into <code>javaclassname</code> parameter for each iteration.</p>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_xmlfile_child_elements">&lt;xmlfile&gt; child elements</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 80%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Child element</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;namespace&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>The namespace referenced in XML files. This element contains two optional attributes: The <code>prefix</code> and the <code>uri</code>.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;namespace prefix="abc" uri="http://maven.apache.org/POM/4.0.0"/&gt;</code></pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="project-syntax_rules-development-guide-appcat">&lt;project&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_3">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;project&gt;</code> element to query the Maven POM file for the project characteristics. For a better understanding of the <code>&lt;project&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/project/condition/Project.html">Project</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that checks for a JUnit dependency version between 2.0.0.Final and 2.2.0.Final.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="UNIQUE_RULE_ID"&gt;
     &lt;when&gt;
         &lt;project&gt;
@@ -1853,253 +1853,253 @@ which may have useful side effects, like setting the matched value on the rule v
         &lt;lineitem message="The project uses junit with the version between 2.0.0.Final and 2.2.0.Final"/&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_project_element">Construct a &lt;project&gt; element</h6>
-<div class="sect6">
-<h7 id="_project_element_attributes">&lt;project&gt; element attributes</h7>
-<div class="paragraph">
-<p>The <code>&lt;project&gt;</code> element is used to match against the project&#8217;s Maven POM file. You can use this condition to query for dependencies of the project. It does not have any attributes itself.</p>
-</div>
-</div>
-<div class="sect6">
-<h7 id="_project_child_elements">&lt;project&gt; child elements</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;artifact&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Subcondition used within <code>&lt;project&gt;</code> to query against project dependencies. The <code>&lt;artifact&gt;</code> element attributes are described below.</p>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect6">
-<h7 id="_artifact_element_attributes">&lt;artifact&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">groupId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PROJECT_GROUP_ID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Match on the project <code>&lt;groupId&gt;</code> of the dependency.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">artifactId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PROJECT_ARTIFACT_ID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Match on the project <code>&lt;artifactId&gt;</code> of the dependency.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">fromVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">FROM_VERSION</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specify the lower version bound of the artifact. For example <code>2.0.0.Final</code>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">toVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">TO_VERSION</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specify the upper version bound of the artifact. For example <code>2.2.0.Final</code>.</p></td>
-</tr>
-</tbody>
-</table>
-<div class="paragraph">
-<p>It is possible to qualify the element within the POM file that contains the artifact that the rule is searching for.
-This is achieved using the optional <code>&lt;location&gt;</code> element.
-The example below shows a rule that is searching for an artifact within the <code>&lt;plugins&gt;</code> element of the POM file.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/search_for_artifact.png" alt="rule searching for artifact">
-</div>
-</div>
-<div class="paragraph">
-<p>The valid list of locations is as follows:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>DEPENDENCY_MANAGEMENT</p>
-</li>
-<li>
-<p>DEPENDENCIES</p>
-</li>
-<li>
-<p>PLUGIN_MANAGEMENT</p>
-</li>
-<li>
-<p>PLUGINS</p>
-</li>
-<li>
-<p>PARENT</p>
-</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="filecontent-syntax_rules-development-guide-appcat">&lt;filecontent&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_4">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;filecontent&gt;</code> element to find strings or text within files, for example, a line in a Properties file. For a better understanding of the <code>&lt;filecontent&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/files/condition/FileContent.html">FileContent</a> class.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_filecontent_element">Construct a &lt;filecontent&gt; element</h6>
-<div class="sect6">
-<h7 id="_filecontent_element_attributes">&lt;filecontent&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">pattern</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Match the file contents against the provided parameterized string. This attribute is required.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">filename</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Match the file names against the provided parameterized string.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">as="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">from="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="file-syntax_rules-development-guide-appcat">&lt;file&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_5">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;file&gt;</code> element to find the existence of files with a specific name, for example, an <code>ibm-webservices-ext.xmi</code> file. For a better understanding of the <code>&lt;file&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/files/condition/File.html">File</a> class.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_file_element">Construct a &lt;file&gt; element</h6>
-<div class="sect6">
-<h7 id="_file_element_attributes">&lt;file&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">filename</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Match the file names against the provided parameterized string. This attribute is required.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">as="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
-</div>
-<div class="paragraph">
-<p><em>Example:</em></p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">from="MyEjbRule"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="has-hint-syntax_rules-development-guide-appcat">&lt;has-hint&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_6">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;has-hint&gt;</code> element to test whether a file or line has a hint already associated with it. It is primarily used to prevent firing if a hint already exists, or to implement rules for default execution when no other conditions apply. For a better understanding of the <code>&lt;has-hint&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HasHint.html">HasHint</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that checks to see if a hint exists for an IBM JMS destination message, and if not includes it.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_project_element">Construct a &lt;project&gt; element</h6>
+                            <div class="sect6">
+                                <h7 id="_project_element_attributes">&lt;project&gt; element attributes</h7>
+                                <div class="paragraph">
+                                    <p>The <code>&lt;project&gt;</code> element is used to match against the project&#8217;s Maven POM file. You can use this condition to query for dependencies of the project. It does not have any attributes itself.</p>
+                                </div>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_project_child_elements">&lt;project&gt; child elements</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 80%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Child element</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;artifact&gt;</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Subcondition used within <code>&lt;project&gt;</code> to query against project dependencies. The <code>&lt;artifact&gt;</code> element attributes are described below.</p>
+                                        </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_artifact_element_attributes">&lt;artifact&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">groupId</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">PROJECT_GROUP_ID</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Match on the project <code>&lt;groupId&gt;</code> of the dependency.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">artifactId</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">PROJECT_ARTIFACT_ID</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Match on the project <code>&lt;artifactId&gt;</code> of the dependency.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">fromVersion</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">FROM_VERSION</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Specify the lower version bound of the artifact. For example <code>2.0.0.Final</code>.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">toVersion</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">TO_VERSION</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Specify the upper version bound of the artifact. For example <code>2.2.0.Final</code>.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                                <div class="paragraph">
+                                    <p>It is possible to qualify the element within the POM file that contains the artifact that the rule is searching for.
+                                        This is achieved using the optional <code>&lt;location&gt;</code> element.
+                                        The example below shows a rule that is searching for an artifact within the <code>&lt;plugins&gt;</code> element of the POM file.</p>
+                                </div>
+                                <div class="imageblock">
+                                    <div class="content">
+                                        <img src="topics/images/search_for_artifact.png" alt="rule searching for artifact">
+                                    </div>
+                                </div>
+                                <div class="paragraph">
+                                    <p>The valid list of locations is as follows:</p>
+                                </div>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p>DEPENDENCY_MANAGEMENT</p>
+                                        </li>
+                                        <li>
+                                            <p>DEPENDENCIES</p>
+                                        </li>
+                                        <li>
+                                            <p>PLUGIN_MANAGEMENT</p>
+                                        </li>
+                                        <li>
+                                            <p>PLUGINS</p>
+                                        </li>
+                                        <li>
+                                            <p>PARENT</p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="filecontent-syntax_rules-development-guide-appcat">&lt;filecontent&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_4">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;filecontent&gt;</code> element to find strings or text within files, for example, a line in a Properties file. For a better understanding of the <code>&lt;filecontent&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/files/condition/FileContent.html">FileContent</a> class.</p>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_filecontent_element">Construct a &lt;filecontent&gt; element</h6>
+                            <div class="sect6">
+                                <h7 id="_filecontent_element_attributes">&lt;filecontent&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">pattern</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Match the file contents against the provided parameterized string. This attribute is required.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">filename</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Match the file names against the provided parameterized string.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">as="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">from="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="file-syntax_rules-development-guide-appcat">&lt;file&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_5">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;file&gt;</code> element to find the existence of files with a specific name, for example, an <code>ibm-webservices-ext.xmi</code> file. For a better understanding of the <code>&lt;file&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/files/condition/File.html">File</a> class.</p>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_file_element">Construct a &lt;file&gt; element</h6>
+                            <div class="sect6">
+                                <h7 id="_file_element_attributes">&lt;file&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">filename</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Match the file names against the provided parameterized string. This attribute is required.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">as="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
+                                        </div>
+                                            <div class="paragraph">
+                                                <p><em>Example:</em></p>
+                                            </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="nowrap">from="MyEjbRule"</pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="has-hint-syntax_rules-development-guide-appcat">&lt;has-hint&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_6">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;has-hint&gt;</code> element to test whether a file or line has a hint already associated with it. It is primarily used to prevent firing if a hint already exists, or to implement rules for default execution when no other conditions apply. For a better understanding of the <code>&lt;has-hint&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HasHint.html">HasHint</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that checks to see if a hint exists for an IBM JMS destination message, and if not includes it.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="websphere-jms-eap7-03000"&gt;
   &lt;when&gt;
     &lt;javaclass references="{package}.{prefix}{type}Message" /&gt;
@@ -2134,91 +2134,91 @@ The example below shows a rule that is searching for an artifact within the <cod
     &lt;matches pattern="com.ibm(\..*)?\.jms" /&gt;
   &lt;/where&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_has_hint">Construct a &lt;has-hint&gt;</h6>
-<div class="paragraph">
-<p>The <code>&lt;has-hint&gt;</code> element is used to determine if a hint exists for a file or line. It does not have any child elements.</p>
-</div>
-<div class="sect6">
-<h7 id="_has_hint_element_attributes">&lt;has-hint&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument allowing you to match the hint against the provided message string.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="has-classification-syntax_rules-development-guide-appcat">&lt;has-classification&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_7">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;has-classification&gt;</code> element to test whether a file or line has a classification. It is primarily used to prevent firing if a classification already exists, or to implement rules for default execution when no other conditions apply. For a better understanding of the <code>&lt;has-classification&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HasClassification.html">HasClassification</a> class.</p>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_has_classification">Construct a &lt;has-classification&gt;</h6>
-<div class="paragraph">
-<p>The <code>has-classification</code> element is used to determine if a specified classification exists. It does not have any child elements.</p>
-</div>
-<div class="sect6">
-<h7 id="_has_classification_element_attributes">&lt;has-classification&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional title to match the classification against.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="graph-query-syntax_rules-development-guide-appcat">&lt;graph-query&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_8">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;graph-query&gt;</code> element to search the generated graph for any elements. This element is primarily used to search for specific archives. For a better understanding of the <code>&lt;graph-query&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/parser/xml/when/QueryHandler.html">QueryHandler</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that tests to determine if any <code>ehcache</code> packages are found.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_has_hint">Construct a &lt;has-hint&gt;</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;has-hint&gt;</code> element is used to determine if a hint exists for a file or line. It does not have any child elements.</p>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_has_hint_element_attributes">&lt;has-hint&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument allowing you to match the hint against the provided message string.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="has-classification-syntax_rules-development-guide-appcat">&lt;has-classification&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_7">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;has-classification&gt;</code> element to test whether a file or line has a classification. It is primarily used to prevent firing if a classification already exists, or to implement rules for default execution when no other conditions apply. For a better understanding of the <code>&lt;has-classification&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HasClassification.html">HasClassification</a> class.</p>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_has_classification">Construct a &lt;has-classification&gt;</h6>
+                            <div class="paragraph">
+                                <p>The <code>has-classification</code> element is used to determine if a specified classification exists. It does not have any child elements.</p>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_has_classification_element_attributes">&lt;has-classification&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">An optional title to match the classification against.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="graph-query-syntax_rules-development-guide-appcat">&lt;graph-query&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_8">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;graph-query&gt;</code> element to search the generated graph for any elements. This element is primarily used to search for specific archives. For a better understanding of the <code>&lt;graph-query&gt;</code> condition, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/parser/xml/when/QueryHandler.html">QueryHandler</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that tests to determine if any <code>ehcache</code> packages are found.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="embedded-cache-libraries-01000"&gt;
     &lt;when&gt;
         &lt;graph-query discriminator="JarArchiveModel"&gt;
@@ -2236,107 +2236,107 @@ The example below shows a rule that is searching for an artifact within the <cod
         &lt;technology-tag level="INFORMATIONAL"&gt;Ehcache (embedded)&lt;/technology-tag&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_construct_a_graph_query">Construct a &lt;graph-query&gt;</h6>
-<div class="sect6">
-<h7 id="_graph_query_element_attributes">&lt;graph-query&gt; element attributes</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">discriminator</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">MODEL_TYPE</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The type of model to use for searching. This can be any valid model; however, it is recommended to use the <code>JarArchiveModel</code> for examining archives. This attribute is required.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">as="MyEjbRule"</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">from="MyEjbRule"</code></pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect6">
-<h7 id="_graph_query_properties">&lt;graph-query&gt; properties</h7>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Property Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The name of the attribute to match against within the chosen model. When using any file-based models it is recommended to match on <code>fileName</code>. This attribute is required.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">property-type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the expected type of property, either <code>STRING</code> or <code>BOOLEAN</code>.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">searchType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">property-search-type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Defines how the condition is matched. If set to <code>equals</code>, then an exact match must be made. If using <code>regex</code>, then regular expressions can be used.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="dependency-syntax_rules-development-guide-appcat">&lt;dependency&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_9">Summary</h6>
-<div class="paragraph">
-<p>Use the <code>&lt;dependency&gt;</code> element to search dependencies defined within the application&#8217;s POM file to determine whether they are supported by the target runtime.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that checks for all artifacts belonging to the <code>org.springframework.boot</code> group that have a version up to, and including, 1.6.0.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_construct_a_graph_query">Construct a &lt;graph-query&gt;</h6>
+                            <div class="sect6">
+                                <h7 id="_graph_query_element_attributes">&lt;graph-query&gt; element attributes</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">discriminator</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">MODEL_TYPE</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The type of model to use for searching. This can be any valid model; however, it is recommended to use the <code>JarArchiveModel</code> for examining archives. This attribute is required.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">as</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>A variable name assigned to the rule so that it can be used as a reference in later processing. See the <code>from</code> attribute below.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="highlight"><code class="language-terminal" data-lang="terminal">as="MyEjbRule"</code></pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">from</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                        <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                            <p>Begin the search query with the filtered result from a previous search identified by its <code>as</code> VARIABLE_NAME.</p>
+                                        </div>
+                                            <div class="listingblock">
+                                                <div class="content">
+                                                    <pre class="highlight"><code class="language-terminal" data-lang="terminal">from="MyEjbRule"</code></pre>
+                                                </div>
+                                            </div></div></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="sect6">
+                                <h7 id="_graph_query_properties">&lt;graph-query&gt; properties</h7>
+                                <table class="tableblock frame-all grid-all stretch">
+                                    <colgroup>
+                                        <col style="width: 20%;">
+                                        <col style="width: 20%;">
+                                        <col style="width: 60%;">
+                                    </colgroup>
+                                    <thead>
+                                    <tr>
+                                        <th class="tableblock halign-left valign-top">Property Name</th>
+                                        <th class="tableblock halign-left valign-top">Type</th>
+                                        <th class="tableblock halign-left valign-top">Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">The name of the attribute to match against within the chosen model. When using any file-based models it is recommended to match on <code>fileName</code>. This attribute is required.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">property-type</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Defines the expected type of property, either <code>STRING</code> or <code>BOOLEAN</code>.</p></td>
+                                    </tr>
+                                    <tr>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">searchType</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">property-search-type</p></td>
+                                        <td class="tableblock halign-left valign-top"><p class="tableblock">Defines how the condition is matched. If set to <code>equals</code>, then an exact match must be made. If using <code>regex</code>, then regular expressions can be used.</p></td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="dependency-syntax_rules-development-guide-appcat">&lt;dependency&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_9">Summary</h6>
+                            <div class="paragraph">
+                                <p>Use the <code>&lt;dependency&gt;</code> element to search dependencies defined within the application&#8217;s POM file to determine whether they are supported by the target runtime.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that checks for all artifacts belonging to the <code>org.springframework.boot</code> group that have a version up to, and including, 1.6.0.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="springboot-00001"&gt;
     &lt;!-- rule condition, when it could be fired --&gt;
     &lt;when&gt;
@@ -2352,34 +2352,34 @@ The example below shows a rule that is searching for an artifact within the <cod
         &lt;/hint&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="xml-rule-perform-syntax_rules-development-guide-appcat">3.3.2. <code>&lt;perform&gt;</code> syntax</h4>
-<div class="paragraph">
-<p>Operations available in the <code>perform</code> section of the rule include the classification of application resources, in-line hints for migration steps, links to migration information, and project lineitem reporting. Because XML rules are modeled after the Java-based rule add-ons, links to JavaDocs for the related Java classes are provided for a better understanding of how they behave.</p>
-</div>
-<div class="paragraph">
-<p>You can view the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">complete XML rule schema</a>.</p>
-</div>
-<div class="paragraph">
-<p>The following sections describe the more common XML rule perform actions.</p>
-</div>
-<div class="sect4">
-<h5 id="classification-syntax_rules-development-guide-appcat">&lt;classification&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_10">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;classification&gt;</code> element is used to identify or classify application resources that match the rule. It provides a title that is displayed in the report, a level of effort, and it can also provide links to additional information about how to migrate this resource classification. For a better understanding of the <code>&lt;classification&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/classification/Classification.html">Classification</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that classifies a resource as a WebLogic EAR application deployment descriptor file.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="xml-rule-perform-syntax_rules-development-guide-appcat">3.3.2. <code>&lt;perform&gt;</code> syntax</h4>
+                    <div class="paragraph">
+                        <p>Operations available in the <code>perform</code> section of the rule include the classification of application resources, in-line hints for migration steps, links to migration information, and project lineitem reporting. Because XML rules are modeled after the Java-based rule add-ons, links to JavaDocs for the related Java classes are provided for a better understanding of how they behave.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>You can view the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">complete XML rule schema</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The following sections describe the more common XML rule perform actions.</p>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="classification-syntax_rules-development-guide-appcat">&lt;classification&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_10">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;classification&gt;</code> element is used to identify or classify application resources that match the rule. It provides a title that is displayed in the report, a level of effort, and it can also provide links to additional information about how to migrate this resource classification. For a better understanding of the <code>&lt;classification&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/classification/Classification.html">Classification</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that classifies a resource as a WebLogic EAR application deployment descriptor file.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="XmlWebLogicRules_10vvyf"&gt;
     &lt;when&gt;
         &lt;xmlfile as="default" matches="/*[local-name()='weblogic-application']"&gt;&lt;/xmlfile&gt;
@@ -2390,142 +2390,142 @@ The example below shows a rule that is searching for an artifact within the <cod
         &lt;/iteration&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_classification_element_attributes">&lt;classification&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The title given to this resource. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">title="JBoss Seam Components"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The level of effort assigned to this resource.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">effort="2"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">category-id</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A reference to a category as defined in <code>APPCAT_HOME/rules/migration-core/core.windup.categories.xml</code>. The default categories are <code>mandatory</code>, <code>optional</code>, <code>potential</code>, and <code>information</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">category-id="mandatory"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">of</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Create a new classification for the given reference.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">of="MySeamRule"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_classification_child_elements">&lt;classification&gt; child elements</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Provides a link URI and text title for additional information.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_classification_element_attributes">&lt;classification&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>The title given to this resource. This attribute is required.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">title="JBoss Seam Components"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>The level of effort assigned to this resource.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">effort="2"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">category-id</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>A reference to a category as defined in <code>APPCAT_HOME/rules/migration-core/core.windup.categories.xml</code>. The default categories are <code>mandatory</code>, <code>optional</code>, <code>potential</code>, and <code>information</code>.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">category-id="mandatory"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">of</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Create a new classification for the given reference.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">of="MySeamRule"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_classification_child_elements">&lt;classification&gt; child elements</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 80%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Child element</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Provides a link URI and text title for additional information.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;classification title="Websphere Startup Service" effort="4"&gt;
    &lt;link href="http://docs.oracle.com/javaee/6/api/javax/ejb/Singleton.html" title="EJB3.1 Singleton Bean"/&gt;
    &lt;link href="http://docs.oracle.com/javaee/6/api/javax/ejb/Startup.html" title="EJB3.1 Startup Bean"/&gt;
 &lt;/classification&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;tag&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Provides additional custom information for the classification.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;tag&gt;Seam3&lt;/tag&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;description&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Description of this resource</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;description&gt;JBoss Seam components must be replaced&lt;/description&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect4">
-<h5 id="link-syntax_rules-development-guide-appcat">&lt;link&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_11">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;link&gt;</code> element is used in classifications or hints to provide links to informational content. For a better understanding of the <code>&lt;link&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/Link.html">Link</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that creates links to additional information.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;tag&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Provides additional custom information for the classification.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;tag&gt;Seam3&lt;/tag&gt;</code></pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;description&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Description of this resource</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;description&gt;JBoss Seam components must be replaced&lt;/description&gt;</code></pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="link-syntax_rules-development-guide-appcat">&lt;link&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_11">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;link&gt;</code> element is used in classifications or hints to provide links to informational content. For a better understanding of the <code>&lt;link&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/Link.html">Link</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that creates links to additional information.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="SeamToCDIRules_2fmb"&gt;
     &lt;when&gt;
         &lt;javaclass references="org.jboss.seam.{*}" as="default"/&gt;
@@ -2541,65 +2541,65 @@ The example below shows a rule that is searching for an artifact within the <cod
         &lt;/iteration&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_link_element_attributes">&lt;link&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">href</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">URI</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The URI for the referenced link.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">href="https://access.redhat.com/articles/1249423"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A title for the link.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">title="Migrate WebLogic Proprietary Servlet Annotations"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect4">
-<h5 id="hint-syntax_rules-development-guide-appcat">&lt;hint&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_12">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;hint&gt;</code> element is used to provide a hint or inline information about how to migrate a section of code. For a better understanding of the <code>&lt;hint&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/Hint.html">Hint</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that creates a hint.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_link_element_attributes">&lt;link&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">href</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">URI</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>The URI for the referenced link.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">href="https://access.redhat.com/articles/1249423"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>A title for the link.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">title="Migrate WebLogic Proprietary Servlet Annotations"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="hint-syntax_rules-development-guide-appcat">&lt;hint&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_12">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;hint&gt;</code> element is used to provide a hint or inline information about how to migrate a section of code. For a better understanding of the <code>&lt;hint&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/Hint.html">Hint</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that creates a hint.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="WebLogicWebServiceRules_8jyqn"&gt;
     &lt;when&gt;
         &lt;javaclass references="weblogic.wsee.connection.transport.http.HttpTransportInfo.setUsername({*})" as="default"&gt;
@@ -2615,154 +2615,154 @@ The example below shows a rule that is searching for an artifact within the <cod
         &lt;/iteration&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_hint_element_attributes">&lt;hint&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Title this hint using the specified string. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">title="JBoss Seam Component Hint"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">category-id</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A reference to a category as defined in <code>APPCAT_HOME/rules/migration-core/core.windup.categories.xml</code>. The default categories are <code>mandatory</code>, <code>optional</code>, <code>potential</code>, and <code>information</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">category-id="mandatory"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Create a new Hint in the FileLocationModel resolved by the given variable.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">in="Foo"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>The level of effort assigned to this resource.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">effort="2"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_hint_child_elements">&lt;hint&gt; child elements</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;message&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A message describing the migration hint.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;message&gt;EJB 2.0 is deprecated&lt;/message&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Identify or classify links to informational content.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_hint_element_attributes">&lt;hint&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Title this hint using the specified string. This attribute is required.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">title="JBoss Seam Component Hint"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">category-id</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>A reference to a category as defined in <code>APPCAT_HOME/rules/migration-core/core.windup.categories.xml</code>. The default categories are <code>mandatory</code>, <code>optional</code>, <code>potential</code>, and <code>information</code>.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">category-id="mandatory"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Create a new Hint in the FileLocationModel resolved by the given variable.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">in="Foo"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>The level of effort assigned to this resource.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">effort="2"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_hint_child_elements">&lt;hint&gt; child elements</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 80%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Child element</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;message&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>A message describing the migration hint.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;message&gt;EJB 2.0 is deprecated&lt;/message&gt;</code></pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;link&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Identify or classify links to informational content.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;link href="http://docs.oracle.com/javaee/6/api/" title="Java Platform, Enterprise Edition 6
 API Specification" /&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;tag&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Define a custom tag for this <code>hint</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;tag&gt;Needs review&lt;/tag&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;quickfix&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Contains information to be used by the AppCAT plugin to perform quick fixes when the rule condition is met.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;tag&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Define a custom tag for this <code>hint</code>.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;tag&gt;Needs review&lt;/tag&gt;</code></pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;quickfix&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Contains information to be used by the AppCAT plugin to perform quick fixes when the rule condition is met.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;quickfix name="slink-qf" type="REPLACE"&gt;
     &lt;replacement&gt;h:link&lt;/replacement&gt;
     &lt;search&gt;s:link&lt;/search&gt;
 &lt;/quickfix&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect4">
-<h5 id="xslt-syntax_rules-development-guide-appcat">&lt;xslt&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_13">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;xslt&gt;</code> element specifies how to transform an XML file. For a better understanding of the <code>&lt;xslt&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.html">XSLTTransformation</a>  class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of rule that defines an XSLT action.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="xslt-syntax_rules-development-guide-appcat">&lt;xslt&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_13">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;xslt&gt;</code> element specifies how to transform an XML file. For a better understanding of the <code>&lt;xslt&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/apps/xml/operation/xslt/XSLTTransformation.html">XSLTTransformation</a>  class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of rule that defines an XSLT action.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="XmlWebLogicRules_6bcvk"&gt;
     &lt;when&gt;
         &lt;xmlfile as="default" matches="/weblogic-ejb-jar"/&gt;
@@ -2774,122 +2774,122 @@ API Specification" /&gt;</code></pre>
         &lt;/iteration&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_xslt_element_attributes">&lt;xslt&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Sets the title for this XSLTTransformation in the report. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">title="XSLT Transformed Output"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">of</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Create a new transformation for the given reference.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">of="testVariable_instance"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">extension</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Sets the extension for this XSLTTransformation. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">extension="-result.html"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Sets the XSL template. This attribute is required.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">template="simpleXSLT.xsl"</pre>
-</div>
-</div></div></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The level of effort required for the transformation.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_xslt_child_elements">&lt;xslt&gt; child elements</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xslt-parameter&gt;</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Specify XSLTTransformation parameters as property value pairs</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-xml" data-lang="xml">&lt;xslt-parameter property="title" value="EJB Transformation"/&gt;</code></pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect4">
-<h5 id="lineitem-syntax_rules-development-guide-appcat">&lt;lineitem&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_14">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;lineitem&gt;</code> element is used to provide  general migration requirements for the application, such as the need to replace deprecated libraries or the need to resolve potential class loading issues. This information is displayed on the project or application overview page. For a better understanding of the <code>&lt;lineitem&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/project/operation/LineItem.html">LineItem</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that creates a lineitem message.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_xslt_element_attributes">&lt;xslt&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">title</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Sets the title for this XSLTTransformation in the report. This attribute is required.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">title="XSLT Transformed Output"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">of</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Create a new transformation for the given reference.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">of="testVariable_instance"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">extension</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Sets the extension for this XSLTTransformation. This attribute is required.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">extension="-result.html"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Sets the XSL template. This attribute is required.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">template="simpleXSLT.xsl"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">effort</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">BYTE</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">The level of effort required for the transformation.</p></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_xslt_child_elements">&lt;xslt&gt; child elements</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 80%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Child element</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;xslt-parameter&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Specify XSLTTransformation parameters as property value pairs</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;xslt-parameter property="title" value="EJB Transformation"/&gt;</code></pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="lineitem-syntax_rules-development-guide-appcat">&lt;lineitem&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_14">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;lineitem&gt;</code> element is used to provide  general migration requirements for the application, such as the need to replace deprecated libraries or the need to resolve potential class loading issues. This information is displayed on the project or application overview page. For a better understanding of the <code>&lt;lineitem&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/project/operation/LineItem.html">LineItem</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that creates a lineitem message.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="weblogic_servlet_annotation_1000"&gt;
     &lt;when&gt;
         &lt;javaclass references="weblogic.servlet.annotation.WLServlet" as="default"&gt;
@@ -2904,53 +2904,53 @@ API Specification" /&gt;</code></pre>
         &lt;/hint&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_lineitem_element_attributes">&lt;lineitem&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>A lineitem message.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">message="Proprietary code found."</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect4">
-<h5 id="iteration-syntax_rules-development-guide-appcat">&lt;iteration&gt; syntax</h5>
-<div class="sect5">
-<h6 id="_summary_15">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;iteration&gt;</code> element specifies to iterate over an implicit or explicit variable defined within the rule. For a better understanding of the <code>&lt;iteration&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/operation/Iteration.html">Iteration</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a rule that performs an iteration.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_lineitem_element_attributes">&lt;lineitem&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">STRING</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>A lineitem message.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">message="Proprietary code found."</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="iteration-syntax_rules-development-guide-appcat">&lt;iteration&gt; syntax</h5>
+                        <div class="sect5">
+                            <h6 id="_summary_15">Summary</h6>
+                            <div class="paragraph">
+                                <p>The <code>&lt;iteration&gt;</code> element specifies to iterate over an implicit or explicit variable defined within the rule. For a better understanding of the <code>&lt;iteration&gt;</code> action, see the JavaDoc for the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/config/operation/Iteration.html">Iteration</a> class.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>The following is an example of a rule that performs an iteration.</p>
+                            </div>
+                            <div class="listingblock">
+                                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="jboss-eap5-xml-19000"&gt;
     &lt;when&gt;
         &lt;xmlfile as="jboss-app" matches="/jboss-app"/&gt;
@@ -2968,79 +2968,79 @@ API Specification" /&gt;</code></pre>
         &lt;/iteration&gt;
     &lt;/perform&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-</div>
-<div class="sect5">
-<h6 id="_iteration_element_attributes">&lt;iteration&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">over</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
-<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
-<p>Iterate over the condition identified by this VARIABLE_NAME.</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">over="jboss-app"</pre>
-</div>
-</div></div></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect5">
-<h6 id="_iteration_child_elements">&lt;iteration&gt; child elements</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 80%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Child Element</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;iteration&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Child elements include a <code>when</code> condition, along with the actions <code>iteration</code>, <code>classification</code>, <code>hint</code>, <code>xslt</code>, <code>lineitem</code>, and <code>otherwise</code>.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="where-syntax_rules-development-guide-appcat">3.3.3. <code>&lt;where&gt;</code> syntax</h4>
-<div class="paragraph">
-<p>You can define parameters that specify a matching pattern to be used in other elements of an XML rule. This can help simplify the patterns for complex matching expressions.</p>
-</div>
-<div class="paragraph">
-<p>Use the <code>&lt;where&gt;</code> element to define a parameter. Specify the parameter name using the <code>param</code> attribute and supply the pattern using the <code>&lt;matches&gt;</code> element. This parameter can then be referenced elsewhere in the rule definition using the syntax <code>{&lt;PARAM_NAME&gt;}</code>.</p>
-</div>
-<div class="paragraph">
-<p>You can view the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">complete XML rule schema</a>.</p>
-</div>
-<div class="paragraph">
-<p>The following example rule defines a parameter named <code>subpackage</code> that specifies a pattern of <code>(activeio|activemq)</code>.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_iteration_element_attributes">&lt;iteration&gt; element attributes</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 20%;">
+                                    <col style="width: 60%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Attribute name</th>
+                                    <th class="tableblock halign-left valign-top">Type</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">over</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">VARIABLE_NAME</p></td>
+                                    <td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+                                        <p>Iterate over the condition identified by this VARIABLE_NAME.</p>
+                                    </div>
+                                        <div class="listingblock">
+                                            <div class="content">
+                                                <pre class="nowrap">over="jboss-app"</pre>
+                                            </div>
+                                        </div></div></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="sect5">
+                            <h6 id="_iteration_child_elements">&lt;iteration&gt; child elements</h6>
+                            <table class="tableblock frame-all grid-all stretch">
+                                <colgroup>
+                                    <col style="width: 20%;">
+                                    <col style="width: 80%;">
+                                </colgroup>
+                                <thead>
+                                <tr>
+                                    <th class="tableblock halign-left valign-top">Child Element</th>
+                                    <th class="tableblock halign-left valign-top">Description</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;iteration&gt;</p></td>
+                                    <td class="tableblock halign-left valign-top"><p class="tableblock">Child elements include a <code>when</code> condition, along with the actions <code>iteration</code>, <code>classification</code>, <code>hint</code>, <code>xslt</code>, <code>lineitem</code>, and <code>otherwise</code>.</p></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="where-syntax_rules-development-guide-appcat">3.3.3. <code>&lt;where&gt;</code> syntax</h4>
+                    <div class="paragraph">
+                        <p>You can define parameters that specify a matching pattern to be used in other elements of an XML rule. This can help simplify the patterns for complex matching expressions.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>Use the <code>&lt;where&gt;</code> element to define a parameter. Specify the parameter name using the <code>param</code> attribute and supply the pattern using the <code>&lt;matches&gt;</code> element. This parameter can then be referenced elsewhere in the rule definition using the syntax <code>{&lt;PARAM_NAME&gt;}</code>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>You can view the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">complete XML rule schema</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The following example rule defines a parameter named <code>subpackage</code> that specifies a pattern of <code>(activeio|activemq)</code>.</p>
+                    </div>
+                    <div class="listingblock">
+                        <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="generic-catchall-00600"&gt;
   &lt;when&gt;
     &lt;javaclass references="org.apache.{subpackage}.{*}"&gt;
@@ -3053,152 +3053,152 @@ API Specification" /&gt;</code></pre>
     &lt;matches pattern="(activeio|activemq)" /&gt;
   &lt;/where&gt;
 &lt;/rule&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The pattern defined by <code>subpackage</code> will then be substituted in the <code>&lt;javaclass&gt;</code> <code>references</code> attribute. This causes the rule to match on <code>org.apache.activeio.*</code> and <code>org.apache.activemq.*</code> packages.</p>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="add-rule-to-mtr_rules-development-guide-appcat">3.4. Adding a rule to the Azure Application and Code Assessment Toolkit</h3>
-<div class="paragraph">
-<p>A Azure Application and Code Assessment Toolkit rule is installed by copying the rule to the appropriate APPCAT folder. APPCAT scans for rules, which are files with the <code>.windup.xml</code> extension in the following locations:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>Directory specified by the <code>--userRulesDirectory</code> argument on the APPCAT command line.</p>
-</li>
-<li>
-<p><code>&lt;APPCAT_HOME&gt;/rules/</code> directory. <code>&lt;APPCAT_HOME&gt;</code> is the directory where you install and run the Azure Application and Code Assessment Toolkit executable.</p>
-</li>
-<li>
-<p><code>${user.home}/.appcat/rules/</code> directory. This directory is created by APPCAT the first time it is run. it contains rules, add-ons, and the APPCAT log.</p>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>In a Windows operating system, the rules are located in <code>\Documents and Settings\&lt;USER_NAME&gt;\.appcat\rules\</code> or <code>\Users\&lt;USER_NAME&gt;\.appcat\rules\</code>.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="testing-rules_rules-development-guide-appcat">4. Testing XML rules</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>After you have created an XML rule, you should create a test rule to ensure that it works.</p>
-</div>
-<div class="sect2">
-<h3 id="_creating_a_test_rule">4.1. Creating a test rule</h3>
-<div class="paragraph">
-<p>Test rules are created using a process similar to the process for creating a test rule, with the following differences:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p>Test rules should be placed in a <code>tests/</code> directory beneath the rule to be tested.</p>
-</li>
-<li>
-<p>Any data, such as test classes, should be placed in a <code>data/</code> directory beneath the <code>tests/</code> directory.</p>
-</li>
-<li>
-<p>Test rules should use the <code>.windup.test.xml</code> extension.</p>
-</li>
-<li>
-<p>These rules use the structure defined in the Test XML Rule Structure.</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>In addition, it is recommended to create a test rule that follows the name of the rule it tests. For instance, if a rule were created with a filename of <code>proprietary-rule.appcat.xml</code>, the test rule should be called <code>proprietary-rule.windup.test.xml</code>.</p>
-</div>
-<div class="sect3">
-<h4 id="test-xml-rule-structure_rules-development-guide-appcat">4.1.1. Test XML rule structure</h4>
-<div class="paragraph">
-<p>All test XML rules are defined as elements within <code>ruletests</code> which contain one or more <code>rulesets</code>. For more details, see the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">APPCAT XML rule schema</a>.</p>
-</div>
-<div class="paragraph">
-<p>A ruletest is a group of one or more tests that targets a specific area of migration. This is the basic structure of the <code>&lt;ruletest&gt;</code> element.</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>&lt;ruletest id="&lt;RULE_TOPIC&gt;-test"&gt;</code>: Defines this as a unique APPCAT ruletest and gives it a unique ruletest id.</p>
-<div class="ulist">
-<ul>
-<li>
-<p><code>&lt;testDataPath&gt;</code>: Defines the path to any data, such as classes or files, used for testing.</p>
-</li>
-<li>
-<p><code>&lt;sourceMode&gt;</code>: Indicates if the passed in data only contains source files. If an archive, such as an EAR, WAR, or JAR, is in use, then this should be set to <code>false</code>. Defaults to <code>true</code>.</p>
-</li>
-<li>
-<p><code>&lt;rulePath&gt;</code>: The path to the rule to be tested. This should end in the name of the rule to test.</p>
-</li>
-<li>
-<p><code>&lt;ruleset&gt;</code>: Rulesets containing the logic of the test cases. These are identical to the ones defined in Rulesets.</p>
-</li>
-</ul>
-</div>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_test_xml_rule_syntax">4.1.2. Test XML rule syntax</h4>
-<div class="paragraph">
-<p>In addition to the tags in the standard XML rule syntax, the following <code>when</code> conditions are commonly used for creating test rules:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>&lt;not&gt;</code></p>
-</li>
-<li>
-<p><code>&lt;iterable-filter&gt;</code></p>
-</li>
-<li>
-<p><code>&lt;classification-exists&gt;</code></p>
-</li>
-<li>
-<p><code>&lt;hint-exists&gt;</code></p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p>In addition to the tags in the standard <code>perform action</code> syntax, the following <code>perform</code> conditions are commonly used as actions in test rules:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><code>&lt;fail&gt;</code></p>
-</li>
-</ul>
-</div>
-<div class="sect4">
-<h5 id="not-syntax_rules-development-guide-appcat">&lt;not&gt; syntax</h5>
-<h6 id="_summary_16" class="discrete">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;not&gt;</code> element is the standard logical <em>not</em> operator, and is commonly used to perform a <code>&lt;fail&gt;</code> if the condition is not met.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example of a test rule that fails if only a specific message exists at the end of the analysis.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                        </div>
+                    </div>
+                    <div class="paragraph">
+                        <p>The pattern defined by <code>subpackage</code> will then be substituted in the <code>&lt;javaclass&gt;</code> <code>references</code> attribute. This causes the rule to match on <code>org.apache.activeio.*</code> and <code>org.apache.activemq.*</code> packages.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="add-rule-to-mtr_rules-development-guide-appcat">3.4. Adding a rule to the Azure Migrate application and code assessment for Java</h3>
+                <div class="paragraph">
+                    <p>A Azure Migrate application and code assessment for Java rule is installed by copying the rule to the appropriate APPCAT folder. APPCAT scans for rules, which are files with the <code>.windup.xml</code> extension in the following locations:</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>Directory specified by the <code>--userRulesDirectory</code> argument on the APPCAT command line.</p>
+                        </li>
+                        <li>
+                            <p><code>&lt;APPCAT_HOME&gt;/rules/</code> directory. <code>&lt;APPCAT_HOME&gt;</code> is the directory where you install and run the Azure Migrate application and code assessment for Java executable.</p>
+                        </li>
+                        <li>
+                            <p><code>${user.home}/.appcat/rules/</code> directory. This directory is created by APPCAT the first time it is run. it contains rules, add-ons, and the APPCAT log.</p>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>In a Windows operating system, the rules are located in <code>\Documents and Settings\&lt;USER_NAME&gt;\.appcat\rules\</code> or <code>\Users\&lt;USER_NAME&gt;\.appcat\rules\</code>.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="testing-rules_rules-development-guide-appcat">4. Testing XML rules</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>After you have created an XML rule, you should create a test rule to ensure that it works.</p>
+            </div>
+            <div class="sect2">
+                <h3 id="_creating_a_test_rule">4.1. Creating a test rule</h3>
+                <div class="paragraph">
+                    <p>Test rules are created using a process similar to the process for creating a test rule, with the following differences:</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p>Test rules should be placed in a <code>tests/</code> directory beneath the rule to be tested.</p>
+                        </li>
+                        <li>
+                            <p>Any data, such as test classes, should be placed in a <code>data/</code> directory beneath the <code>tests/</code> directory.</p>
+                        </li>
+                        <li>
+                            <p>Test rules should use the <code>.windup.test.xml</code> extension.</p>
+                        </li>
+                        <li>
+                            <p>These rules use the structure defined in the Test XML Rule Structure.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="paragraph">
+                    <p>In addition, it is recommended to create a test rule that follows the name of the rule it tests. For instance, if a rule were created with a filename of <code>proprietary-rule.appcat.xml</code>, the test rule should be called <code>proprietary-rule.windup.test.xml</code>.</p>
+                </div>
+                <div class="sect3">
+                    <h4 id="test-xml-rule-structure_rules-development-guide-appcat">4.1.1. Test XML rule structure</h4>
+                    <div class="paragraph">
+                        <p>All test XML rules are defined as elements within <code>ruletests</code> which contain one or more <code>rulesets</code>. For more details, see the <a href="http://windup.jboss.org/schema/windup-jboss-ruleset.xsd">APPCAT XML rule schema</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>A ruletest is a group of one or more tests that targets a specific area of migration. This is the basic structure of the <code>&lt;ruletest&gt;</code> element.</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p><code>&lt;ruletest id="&lt;RULE_TOPIC&gt;-test"&gt;</code>: Defines this as a unique APPCAT ruletest and gives it a unique ruletest id.</p>
+                                <div class="ulist">
+                                    <ul>
+                                        <li>
+                                            <p><code>&lt;testDataPath&gt;</code>: Defines the path to any data, such as classes or files, used for testing.</p>
+                                        </li>
+                                        <li>
+                                            <p><code>&lt;sourceMode&gt;</code>: Indicates if the passed in data only contains source files. If an archive, such as an EAR, WAR, or JAR, is in use, then this should be set to <code>false</code>. Defaults to <code>true</code>.</p>
+                                        </li>
+                                        <li>
+                                            <p><code>&lt;rulePath&gt;</code>: The path to the rule to be tested. This should end in the name of the rule to test.</p>
+                                        </li>
+                                        <li>
+                                            <p><code>&lt;ruleset&gt;</code>: Rulesets containing the logic of the test cases. These are identical to the ones defined in Rulesets.</p>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_test_xml_rule_syntax">4.1.2. Test XML rule syntax</h4>
+                    <div class="paragraph">
+                        <p>In addition to the tags in the standard XML rule syntax, the following <code>when</code> conditions are commonly used for creating test rules:</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p><code>&lt;not&gt;</code></p>
+                            </li>
+                            <li>
+                                <p><code>&lt;iterable-filter&gt;</code></p>
+                            </li>
+                            <li>
+                                <p><code>&lt;classification-exists&gt;</code></p>
+                            </li>
+                            <li>
+                                <p><code>&lt;hint-exists&gt;</code></p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p>In addition to the tags in the standard <code>perform action</code> syntax, the following <code>perform</code> conditions are commonly used as actions in test rules:</p>
+                    </div>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p><code>&lt;fail&gt;</code></p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="not-syntax_rules-development-guide-appcat">&lt;not&gt; syntax</h5>
+                        <h6 id="_summary_16" class="discrete">Summary</h6>
+                        <div class="paragraph">
+                            <p>The <code>&lt;not&gt;</code> element is the standard logical <em>not</em> operator, and is commonly used to perform a <code>&lt;fail&gt;</code> if the condition is not met.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The following is an example of a test rule that fails if only a specific message exists at the end of the analysis.</p>
+                        </div>
+                        <div class="listingblock">
+                            <div class="content">
 <pre class="highlight nowrap"><code class="language-xml" data-lang="xml">&lt;ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
           id="proprietary-servlet-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"&gt;
@@ -3231,23 +3231,23 @@ API Specification" /&gt;</code></pre>
     &lt;/rules&gt;
   &lt;/ruleset&gt;
 &lt;/ruletest&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>&lt;not&gt;</code> element has no unique attributes or child elements.</p>
-</div>
-</div>
-<div class="sect4">
-<h5 id="iterable-filter-syntax_rules-development-guide-appcat">&lt;iterable-filter&gt; syntax</h5>
-<h6 id="_summary_17" class="discrete">Summary</h6>
-<div class="paragraph">
-<p>The <code>&lt;iterable-filter&gt;</code> element counts the number of times a condition is verified. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/general/IterableFilter.html">IterableFilter</a> class.</p>
-</div>
-<div class="paragraph">
-<p>The following is an example that looks for four instances of the specified message.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                            </div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The <code>&lt;not&gt;</code> element has no unique attributes or child elements.</p>
+                        </div>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="iterable-filter-syntax_rules-development-guide-appcat">&lt;iterable-filter&gt; syntax</h5>
+                        <h6 id="_summary_17" class="discrete">Summary</h6>
+                        <div class="paragraph">
+                            <p>The <code>&lt;iterable-filter&gt;</code> element counts the number of times a condition is verified. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/rules/general/IterableFilter.html">IterableFilter</a> class.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The following is an example that looks for four instances of the specified message.</p>
+                        </div>
+                        <div class="listingblock">
+                            <div class="content">
 <pre class="highlight nowrap"><code class="language-xml" data-lang="xml">&lt;ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
           id="proprietary-servlet-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"&gt;
@@ -3280,58 +3280,58 @@ API Specification" /&gt;</code></pre>
     &lt;/rules&gt;
   &lt;/ruleset&gt;
 &lt;/ruletest&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>&lt;iterable-filter&gt;</code> element has no unique child elements.</p>
-</div>
-<h6 id="_iterable_filter_element_attributes" class="discrete">&lt;iterable-filter&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">size</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">integer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The number of times to be verified.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="classification_exists_syntax_rules-development-guide-appcat">&lt;classification-exists&gt; syntax</h5>
-<div class="paragraph">
-<p>The <code>&lt;classification-exists&gt;</code> element determines if a specific classification title has been included in the analysis. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/ClassificationExists.html">ClassificationExists</a> class.</p>
-</div>
-<div class="admonitionblock important">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Important</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>When testing for a message that contains special characters, such as <code>[</code> or <code>'</code>, you must escape each special character with a backslash (<code>\</code>) to correctly match.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>The following is an example that searches for a specific classification title.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                            </div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The <code>&lt;iterable-filter&gt;</code> element has no unique child elements.</p>
+                        </div>
+                        <h6 id="_iterable_filter_element_attributes" class="discrete">&lt;iterable-filter&gt; element attributes</h6>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 20%;">
+                                <col style="width: 60%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                <th class="tableblock halign-left valign-top">Type</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">size</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">integer</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The number of times to be verified.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="classification_exists_syntax_rules-development-guide-appcat">&lt;classification-exists&gt; syntax</h5>
+                        <div class="paragraph">
+                            <p>The <code>&lt;classification-exists&gt;</code> element determines if a specific classification title has been included in the analysis. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/ClassificationExists.html">ClassificationExists</a> class.</p>
+                        </div>
+                        <div class="admonitionblock important">
+                            <table>
+                                <tr>
+                                    <td class="icon">
+                                        <div class="title">Important</div>
+                                    </td>
+                                    <td class="content">
+                                        <div class="paragraph">
+                                            <p>When testing for a message that contains special characters, such as <code>[</code> or <code>'</code>, you must escape each special character with a backslash (<code>\</code>) to correctly match.</p>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div class="paragraph">
+                            <p>The following is an example that searches for a specific classification title.</p>
+                        </div>
+                        <div class="listingblock">
+                            <div class="content">
 <pre class="highlight nowrap"><code class="language-xml" data-lang="xml">&lt;ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
           id="proprietary-servlet-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"&gt;
@@ -3363,63 +3363,63 @@ API Specification" /&gt;</code></pre>
     &lt;/rules&gt;
   &lt;/ruleset&gt;
 &lt;/ruletest&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>&lt;classification-exists&gt;</code> has no unique child elements.</p>
-</div>
-<h6 id="_classification_exists_element_attributes" class="discrete">&lt;classification-exists&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">classification</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The <code>&lt;classification&gt;</code> <code>title</code> to search for.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument that restricts matching to files that contain the defined filename.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="hint-exists-syntax_rules-development-guide-appcat">&lt;hint-exists&gt; syntax</h5>
-<div class="paragraph">
-<p>The <code>&lt;hint-exists&gt;</code> element determines if a specific hint has been included in the analysis. It searches for any instances of the defined message, and is typically used to search for the beginning or a specific class inside of a <code>&lt;message&gt;</code> element. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HintExists.html">HintExists</a> class.</p>
-</div>
-<div class="admonitionblock important">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Important</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>When testing for a message that contains special characters, such as <code>[</code> or <code>'</code>, you must escape each special character with a backslash (<code>\</code>) to correctly match.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<div class="paragraph">
-<p>The following is an example that searches for a specific hint.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                            </div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The <code>&lt;classification-exists&gt;</code> has no unique child elements.</p>
+                        </div>
+                        <h6 id="_classification_exists_element_attributes" class="discrete">&lt;classification-exists&gt; element attributes</h6>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 20%;">
+                                <col style="width: 60%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                <th class="tableblock halign-left valign-top">Type</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">classification</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The <code>&lt;classification&gt;</code> <code>title</code> to search for.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument that restricts matching to files that contain the defined filename.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="hint-exists-syntax_rules-development-guide-appcat">&lt;hint-exists&gt; syntax</h5>
+                        <div class="paragraph">
+                            <p>The <code>&lt;hint-exists&gt;</code> element determines if a specific hint has been included in the analysis. It searches for any instances of the defined message, and is typically used to search for the beginning or a specific class inside of a <code>&lt;message&gt;</code> element. For additional information, see the <a href="http://windup.github.io/windup/docs/latest/javadoc/org/jboss/windup/reporting/config/HintExists.html">HintExists</a> class.</p>
+                        </div>
+                        <div class="admonitionblock important">
+                            <table>
+                                <tr>
+                                    <td class="icon">
+                                        <div class="title">Important</div>
+                                    </td>
+                                    <td class="content">
+                                        <div class="paragraph">
+                                            <p>When testing for a message that contains special characters, such as <code>[</code> or <code>'</code>, you must escape each special character with a backslash (<code>\</code>) to correctly match.</p>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div class="paragraph">
+                            <p>The following is an example that searches for a specific hint.</p>
+                        </div>
+                        <div class="listingblock">
+                            <div class="content">
 <pre class="highlight nowrap"><code class="language-xml" data-lang="xml">&lt;ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
           id="proprietary-servlet-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd"&gt;
@@ -3451,377 +3451,377 @@ API Specification" /&gt;</code></pre>
     &lt;/rules&gt;
   &lt;/ruleset&gt;
 &lt;/ruletest&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>The <code>&lt;hint-exists&gt;</code> element has no unique child elements.</p>
-</div>
-<h6 id="_hint_exists_element_attributes" class="discrete">&lt;hint-exists&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The <code>&lt;hint&gt;</code> <code>message</code> to search for.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument that restricts matching to <code>InLineHintModels</code> that reference the given filename.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="fail-syntax_rules-development-guide-appcat">&lt;fail&gt; syntax</h5>
-<div class="paragraph">
-<p>The <code>&lt;fail&gt;</code> element reports the execution as a failure and displays the associated message. It is commonly used in conjunction with the <code>&lt;not&gt;</code> condition to display a message only if the conditions are not met.</p>
-</div>
-<div class="paragraph">
-<p>The <code>&lt;fail&gt;</code> element has no unique child elements.</p>
-</div>
-<h6 id="_fail_element_attributes" class="discrete">&lt;fail&gt; element attributes</h6>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Attribute Name</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The message to be displayed.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="manually-test-rules_rules-development-guide-appcat">4.2. Manually testing an XML rule</h3>
-<div class="paragraph">
-<p>You can run an XML rule against your application file to test it:</p>
-</div>
-<div class="listingblock">
-<div class="content">
-<pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat-cli [--sourceMode] --input &lt;INPUT_ARCHIVE_OR_FOLDER&gt; --output &lt;OUTPUT_REPORT_DIRECTORY&gt; --target &lt;TARGET_TECHNOLOGY&gt; --packages &lt;PACKAGE_1&gt; &lt;PACKAGE_2&gt; &lt;PACKAGE_N&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>You should see the following result:</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                            </div>
+                        </div>
+                        <div class="paragraph">
+                            <p>The <code>&lt;hint-exists&gt;</code> element has no unique child elements.</p>
+                        </div>
+                        <h6 id="_hint_exists_element_attributes" class="discrete">&lt;hint-exists&gt; element attributes</h6>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 20%;">
+                                <col style="width: 60%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                <th class="tableblock halign-left valign-top">Type</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The <code>&lt;hint&gt;</code> <code>message</code> to search for.</p></td>
+                            </tr>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">in</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">An optional argument that restricts matching to <code>InLineHintModels</code> that reference the given filename.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="fail-syntax_rules-development-guide-appcat">&lt;fail&gt; syntax</h5>
+                        <div class="paragraph">
+                            <p>The <code>&lt;fail&gt;</code> element reports the execution as a failure and displays the associated message. It is commonly used in conjunction with the <code>&lt;not&gt;</code> condition to display a message only if the conditions are not met.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>The <code>&lt;fail&gt;</code> element has no unique child elements.</p>
+                        </div>
+                        <h6 id="_fail_element_attributes" class="discrete">&lt;fail&gt; element attributes</h6>
+                        <table class="tableblock frame-all grid-all stretch">
+                            <colgroup>
+                                <col style="width: 20%;">
+                                <col style="width: 20%;">
+                                <col style="width: 60%;">
+                            </colgroup>
+                            <thead>
+                            <tr>
+                                <th class="tableblock halign-left valign-top">Attribute Name</th>
+                                <th class="tableblock halign-left valign-top">Type</th>
+                                <th class="tableblock halign-left valign-top">Description</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">message</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+                                <td class="tableblock halign-left valign-top"><p class="tableblock">The message to be displayed.</p></td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="manually-test-rules_rules-development-guide-appcat">4.2. Manually testing an XML rule</h3>
+                <div class="paragraph">
+                    <p>You can run an XML rule against your application file to test it:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
+                        <pre class="highlight"><code class="language-terminal" data-lang="terminal">$ &lt;APPCAT_HOME&gt;/bin/appcat [--sourceMode] --input &lt;INPUT_ARCHIVE_OR_FOLDER&gt; --output &lt;OUTPUT_REPORT_DIRECTORY&gt; --target &lt;TARGET_TECHNOLOGY&gt; --packages &lt;PACKAGE_1&gt; &lt;PACKAGE_2&gt; &lt;PACKAGE_N&gt;</code></pre>
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>You should see the following result:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="content">
 <pre class="nowrap">Report created: &lt;OUTPUT_REPORT_DIRECTORY&gt;/index.html
               Access it at this URL: file:///&lt;OUTPUT_REPORT_DIRECTORY&gt;/index.html</pre>
-</div>
-</div>
-<div class="paragraph">
-<p>More examples of how to run APPCAT are located in the Azure Application and Code Assessment Toolkit <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a>.</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="rules-testng-junit_rules-development-guide-appcat">4.3. Testing the rules by using JUnit</h3>
-<div class="paragraph">
-<p>Once a test rule has been created, it can be analyzed as part of a JUnit test to confirm that the rule meets all criteria for execution. The <code>WindupRulesMultipleTests</code> class in the APPCAT rules repository is designed to test multiple rules simultaneously, and provides feedback on any missing requirements.</p>
-</div>
-<div class="ulist">
-<div class="title">Prerequisites</div>
-<ul>
-<li>
-<p>Fork and clone the APPCAT XML rules. The location of this repository will be referred to as &lt;RULESETS_REPO&gt;.</p>
-</li>
-<li>
-<p>Create a test XML rule.</p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<div class="title">Creating the JUnit test configuration</div>
-<p>The following instructions detail creating a JUnit test using the Red Hat CodeReady Studio. When using a different IDE it is recommended to consult your IDE&#8217;s documentation for instructions on creating a JUnit test.</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Import the APPCAT rulesets repository into your IDE.</p>
-</li>
-<li>
-<p>Copy the custom rules, along with the corresponding tests and data, into <code>&lt;/path/to/RULESETS_REPO&gt;/rules-reviewed/&lt;RULE_NAME&gt;/</code>. This should create the following directory structure.</p>
-<div class="listingblock">
-<div class="title">Directory structure</div>
-<div class="content">
+                    </div>
+                </div>
+                <div class="paragraph">
+                    <p>More examples of how to run APPCAT are located in the Azure Migrate application and code assessment for Java <a href="https://azure.github.io/appcat-docs/cli"><em>CLI Guide</em></a>.</p>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="rules-testng-junit_rules-development-guide-appcat">4.3. Testing the rules by using JUnit</h3>
+                <div class="paragraph">
+                    <p>Once a test rule has been created, it can be analyzed as part of a JUnit test to confirm that the rule meets all criteria for execution. The <code>WindupRulesMultipleTests</code> class in the APPCAT rules repository is designed to test multiple rules simultaneously, and provides feedback on any missing requirements.</p>
+                </div>
+                <div class="ulist">
+                    <div class="title">Prerequisites</div>
+                    <ul>
+                        <li>
+                            <p>Fork and clone the APPCAT XML rules. The location of this repository will be referred to as &lt;RULESETS_REPO&gt;.</p>
+                        </li>
+                        <li>
+                            <p>Create a test XML rule.</p>
+                        </li>
+                    </ul>
+                </div>
+                <div class="paragraph">
+                    <div class="title">Creating the JUnit test configuration</div>
+                    <p>The following instructions detail creating a JUnit test using the Red Hat CodeReady Studio. When using a different IDE it is recommended to consult your IDE&#8217;s documentation for instructions on creating a JUnit test.</p>
+                </div>
+                <div class="olist arabic">
+                    <ol class="arabic">
+                        <li>
+                            <p>Import the APPCAT rulesets repository into your IDE.</p>
+                        </li>
+                        <li>
+                            <p>Copy the custom rules, along with the corresponding tests and data, into <code>&lt;/path/to/RULESETS_REPO&gt;/rules-reviewed/&lt;RULE_NAME&gt;/</code>. This should create the following directory structure.</p>
+                            <div class="listingblock">
+                                <div class="title">Directory structure</div>
+                                <div class="content">
 <pre class="highlight nowrap"><code>├── *rules-reviewed/*  _(Root directory of the rules found within the project)_
 │   ├── *&lt;RULE_NAME&gt;/*  _(Directory to contain the newly developed rule and tests)_
 │   │   ├── *&lt;RULE_NAME&gt;.windup.xml*  _(Custom rule)_
 │   │   ├── *tests/*  _(Directory that contains any test rules and data)_
 │   │   │   ├── *&lt;RULE_NAME&gt;.windup.test.xml* _(Test rule)_
 │   │   │   └── *data/*  _(Optional directory to contain test rule data)_</code></pre>
-</div>
-</div>
-</li>
-<li>
-<p>Select <strong>Run</strong> from the top menu bar.</p>
-</li>
-<li>
-<p>Select <strong>Run Configurations&#8230;&#8203;</strong> from the drop down that appears.</p>
-</li>
-<li>
-<p>Right-click <strong>JUnit</strong> from the options on the left side and select <strong>New</strong>.</p>
-</li>
-<li>
-<p>Enter the following:</p>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>Name</strong>: A name for your JUnit test, such as <code>WindupRulesMultipleTests</code>.</p>
-</li>
-<li>
-<p><strong>Project</strong>: Ensure this is set to <code>appcat-rulesets</code>.</p>
-</li>
-<li>
-<p><strong>Test class</strong>: Set this to <code>org.jboss.windup.rules.tests.WindupRulesMultipleTests</code>.</p>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/junit-test.png" alt="junit test">
-</div>
-</div>
-</li>
-</ul>
-</div>
-</li>
-<li>
-<p>Select the <strong>Arguments</strong> tab, and add the <code>-DrunTestsMatching=&lt;RULE_NAME&gt;</code> VM argument. For instance, if your rule name was <code>community-rules</code>, then you would add <code>-DrunTestsMatching=community-rules</code> as seen in the following image.</p>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/junit-test-arguments.png" alt="junit test arguments">
-</div>
-</div>
-</li>
-<li>
-<p>Click <strong>Run</strong> in the bottom right corner to begin the test.</p>
-<div class="paragraph">
-<p>When the execution completes, the results are available for analysis. If all tests passed, then the test rule is correctly formatted. If all tests did not pass, it is recommended to address each of the issues raised in the test failures.</p>
-</div>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="validation-report_rules-development-guide-appcat">4.4. About validation reports</h3>
-<div class="paragraph">
-<p>Validation reports provide details about test rules and failures and contain the following sections:</p>
-</div>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>Summary</strong></p>
-<div class="paragraph">
-<p>This section contains the total number of tests run and reports the number of errors and failures. It displays the total success rate and the time taken, in seconds, for the report to be generated.</p>
-</div>
-</li>
-<li>
-<p><strong>Package List</strong></p>
-<div class="paragraph">
-<p>This section contains the number of tests executed for each package and reports the number of errors and failures. It displays the success rate and the time taken, in seconds, for each package to be analyzed.</p>
-</div>
-<div class="paragraph">
-<p>A single package named <code>org.jboss.windup.rules.tests</code> is displayed unless additional test cases have been defined.</p>
-</div>
-</li>
-<li>
-<p><strong>Test Cases</strong></p>
-<div class="paragraph">
-<p>This section describes the test cases. Each failure includes a <strong>Details</strong> section that can be expanded to show the stack trace for the assertion, including a human-readable line indicating the source of the error.</p>
-</div>
-</li>
-</ul>
-</div>
-<div class="sect3">
-<h4 id="validation-report-understanding_rules-development-guide-appcat">4.4.1. Creating a validation report</h4>
-<div class="paragraph">
-<p>You can create a validation report for your custom rules.</p>
-</div>
-<div class="ulist">
-<div class="title">Prerequisites</div>
-<ul>
-<li>
-<p>You must fork and clone the APPCAT XML rules.</p>
-</li>
-<li>
-<p>You must have one or more test XML rules to validate.</p>
-</li>
-</ul>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Navigate to the local <code>appcat-rulesets</code> repository.</p>
-</li>
-<li>
-<p>Create a directory for your custom rules and tests: <code>appcat-rulesets/rules-reviewed/myTests</code>.</p>
-</li>
-<li>
-<p>Copy your custom rules and tests to the <code>appcat-rulesets/rules-reviewed/&lt;myTests&gt;</code> directory.</p>
-</li>
-<li>
-<p>Run the following command from the root directory of the <code>appcat-rulesets</code> repository:</p>
-<div class="listingblock">
-<div class="content">
-<pre>$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=&lt;myTests&gt; clean &lt;myReport&gt;:report <b class="conum">(1)</b> <b class="conum">(2)</b></pre>
-</div>
-</div>
-<div class="colist arabic">
-<ol>
-<li>
-<p>Specify the directory containing your custom rules and tests. If you omit the <code>-DrunTestsMatching</code> argument, the validation report will include all the tests and take much longer to generate.</p>
-</li>
-<li>
-<p>Specify your report name.</p>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>The validation report is created in the <code>appcat-rulesets/target/site/</code> repository.</p>
-</div>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect3">
-<h4 id="validation-report-errors_rules-development-guide-appcat">4.4.2. Validation report error messages</h4>
-<div class="paragraph">
-<p>Validation reports contain errors encountered while running the rules and tests.</p>
-</div>
-<div class="paragraph">
-<p>The following table contains error messages and how to resolve the errors.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. Validation report error messages</caption>
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 35%;">
-<col style="width: 40%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Error message</th>
-<th class="tableblock halign-left valign-top">Description</th>
-<th class="tableblock halign-left valign-top">Resolution</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">No test file matching rule</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This error occurs when a rule file exists without a corresponding test file.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Create a test file for the existing rule.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Test rule Ids &lt;RULE_NAME&gt; not found!</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This error is thrown when a rule exists without a corresponding ruletest.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Create a test for the existing rule.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">XML parse fail on file &lt;FILE_NAME&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The syntax in the XML file is invalid, and unable to be parsed successfully by the rule validator.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Correct the invalid syntax.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Test file path from <code>&lt;testDataPath&gt;</code> tag has not been found. Expected path to test file is: &lt;RULE_DATA_PATH&gt;</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">No files are found in the path defined in the <code>&lt;testDataPath&gt;</code> tag within the test rule.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Create the path defined in the <code>&lt;testDataPath&gt;</code> tag, and ensure all necessary data files are located within this directory.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rule with id="&lt;RULE_ID&gt;" has not been executed.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rule with the provided id has not been executed during this validation.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ensure that a test data file exists that matches the conditions defined in the specified rule.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="overriding-rules_rules-development-guide-appcat">5. Overriding rules</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>You can override core rules distributed with APPCAT or even custom rules. For example, you can change the matching conditions, effort, or hint text for a rule. This is done by making a copy of the original rule, marking it as a rule override, and making the necessary adjustments.</p>
-</div>
-<div class="paragraph">
-<p>You can disable a rule by creating a rule override with an empty <code>&lt;rule&gt;</code> element.</p>
-</div>
-<div class="sect2">
-<h3 id="_overriding_a_rule">5.1. Overriding a rule</h3>
-<div class="paragraph">
-<p>You can override a core or custom rule.</p>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Copy the XML file that contains the rule you want to override to the custom rules directory.</p>
-<div class="paragraph">
-<p>Custom rules can be placed in <code>&lt;APPCAT_HOME&gt;/rules</code>, <code>${user.home}/.appcat/rules/</code>, or a directory specified by the <code>--userRulesDirectory</code> command-line argument.</p>
-</div>
-</li>
-<li>
-<p>Edit the XML file so that it contains only the <code>&lt;rule&gt;</code> elements for the rules that you want to override.</p>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>Rules from the original ruleset that are not overridden by the new ruleset are run as normal.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-</li>
-<li>
-<p>Ensure that you keep the same rule and ruleset IDs. When you copy the original rule XML, this ensures that the IDs match.</p>
-</li>
-<li>
-<p>Add the <code>&lt;overrideRules&gt;true&lt;/overrideRules&gt;</code> element to the ruleset metadata.</p>
-</li>
-<li>
-<p>Update the rule definition.</p>
-<div class="paragraph">
-<p>You can change anything in the rule definition. The new rule overrides the original rule in its entirety.</p>
-</div>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>The following rule override example changes the <code>effort</code> of the <code>weblogic-02000</code> rule in the <code>weblogic</code> ruleset from <code>1</code> to <code>3</code>:</p>
-</div>
-<div class="listingblock">
-<div class="title">Rule override definition example</div>
-<div class="content">
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Select <strong>Run</strong> from the top menu bar.</p>
+                        </li>
+                        <li>
+                            <p>Select <strong>Run Configurations&#8230;&#8203;</strong> from the drop down that appears.</p>
+                        </li>
+                        <li>
+                            <p>Right-click <strong>JUnit</strong> from the options on the left side and select <strong>New</strong>.</p>
+                        </li>
+                        <li>
+                            <p>Enter the following:</p>
+                            <div class="ulist">
+                                <ul>
+                                    <li>
+                                        <p><strong>Name</strong>: A name for your JUnit test, such as <code>WindupRulesMultipleTests</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p><strong>Project</strong>: Ensure this is set to <code>appcat-rulesets</code>.</p>
+                                    </li>
+                                    <li>
+                                        <p><strong>Test class</strong>: Set this to <code>org.jboss.windup.rules.tests.WindupRulesMultipleTests</code>.</p>
+                                        <div class="imageblock">
+                                            <div class="content">
+                                                <img src="topics/images/junit-test.png" alt="junit test">
+                                            </div>
+                                        </div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Select the <strong>Arguments</strong> tab, and add the <code>-DrunTestsMatching=&lt;RULE_NAME&gt;</code> VM argument. For instance, if your rule name was <code>community-rules</code>, then you would add <code>-DrunTestsMatching=community-rules</code> as seen in the following image.</p>
+                            <div class="imageblock">
+                                <div class="content">
+                                    <img src="topics/images/junit-test-arguments.png" alt="junit test arguments">
+                                </div>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Click <strong>Run</strong> in the bottom right corner to begin the test.</p>
+                            <div class="paragraph">
+                                <p>When the execution completes, the results are available for analysis. If all tests passed, then the test rule is correctly formatted. If all tests did not pass, it is recommended to address each of the issues raised in the test failures.</p>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="validation-report_rules-development-guide-appcat">4.4. About validation reports</h3>
+                <div class="paragraph">
+                    <p>Validation reports provide details about test rules and failures and contain the following sections:</p>
+                </div>
+                <div class="ulist">
+                    <ul>
+                        <li>
+                            <p><strong>Summary</strong></p>
+                            <div class="paragraph">
+                                <p>This section contains the total number of tests run and reports the number of errors and failures. It displays the total success rate and the time taken, in seconds, for the report to be generated.</p>
+                            </div>
+                        </li>
+                        <li>
+                            <p><strong>Package List</strong></p>
+                            <div class="paragraph">
+                                <p>This section contains the number of tests executed for each package and reports the number of errors and failures. It displays the success rate and the time taken, in seconds, for each package to be analyzed.</p>
+                            </div>
+                            <div class="paragraph">
+                                <p>A single package named <code>org.jboss.windup.rules.tests</code> is displayed unless additional test cases have been defined.</p>
+                            </div>
+                        </li>
+                        <li>
+                            <p><strong>Test Cases</strong></p>
+                            <div class="paragraph">
+                                <p>This section describes the test cases. Each failure includes a <strong>Details</strong> section that can be expanded to show the stack trace for the assertion, including a human-readable line indicating the source of the error.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <div class="sect3">
+                    <h4 id="validation-report-understanding_rules-development-guide-appcat">4.4.1. Creating a validation report</h4>
+                    <div class="paragraph">
+                        <p>You can create a validation report for your custom rules.</p>
+                    </div>
+                    <div class="ulist">
+                        <div class="title">Prerequisites</div>
+                        <ul>
+                            <li>
+                                <p>You must fork and clone the APPCAT XML rules.</p>
+                            </li>
+                            <li>
+                                <p>You must have one or more test XML rules to validate.</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="olist arabic">
+                        <div class="title">Procedure</div>
+                        <ol class="arabic">
+                            <li>
+                                <p>Navigate to the local <code>appcat-rulesets</code> repository.</p>
+                            </li>
+                            <li>
+                                <p>Create a directory for your custom rules and tests: <code>appcat-rulesets/rules-reviewed/myTests</code>.</p>
+                            </li>
+                            <li>
+                                <p>Copy your custom rules and tests to the <code>appcat-rulesets/rules-reviewed/&lt;myTests&gt;</code> directory.</p>
+                            </li>
+                            <li>
+                                <p>Run the following command from the root directory of the <code>appcat-rulesets</code> repository:</p>
+                                <div class="listingblock">
+                                    <div class="content">
+                                        <pre>$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=&lt;myTests&gt; clean &lt;myReport&gt;:report <b class="conum">(1)</b> <b class="conum">(2)</b></pre>
+                                    </div>
+                                </div>
+                                <div class="colist arabic">
+                                    <ol>
+                                        <li>
+                                            <p>Specify the directory containing your custom rules and tests. If you omit the <code>-DrunTestsMatching</code> argument, the validation report will include all the tests and take much longer to generate.</p>
+                                        </li>
+                                        <li>
+                                            <p>Specify your report name.</p>
+                                        </li>
+                                    </ol>
+                                </div>
+                                <div class="paragraph">
+                                    <p>The validation report is created in the <code>appcat-rulesets/target/site/</code> repository.</p>
+                                </div>
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="validation-report-errors_rules-development-guide-appcat">4.4.2. Validation report error messages</h4>
+                    <div class="paragraph">
+                        <p>Validation reports contain errors encountered while running the rules and tests.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The following table contains error messages and how to resolve the errors.</p>
+                    </div>
+                    <table class="tableblock frame-all grid-all stretch">
+                        <caption class="title">Table 1. Validation report error messages</caption>
+                        <colgroup>
+                            <col style="width: 25%;">
+                            <col style="width: 35%;">
+                            <col style="width: 40%;">
+                        </colgroup>
+                        <thead>
+                        <tr>
+                            <th class="tableblock halign-left valign-top">Error message</th>
+                            <th class="tableblock halign-left valign-top">Description</th>
+                            <th class="tableblock halign-left valign-top">Resolution</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">No test file matching rule</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">This error occurs when a rule file exists without a corresponding test file.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Create a test file for the existing rule.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Test rule Ids &lt;RULE_NAME&gt; not found!</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">This error is thrown when a rule exists without a corresponding ruletest.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Create a test for the existing rule.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">XML parse fail on file &lt;FILE_NAME&gt;</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The syntax in the XML file is invalid, and unable to be parsed successfully by the rule validator.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Correct the invalid syntax.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Test file path from <code>&lt;testDataPath&gt;</code> tag has not been found. Expected path to test file is: &lt;RULE_DATA_PATH&gt;</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">No files are found in the path defined in the <code>&lt;testDataPath&gt;</code> tag within the test rule.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Create the path defined in the <code>&lt;testDataPath&gt;</code> tag, and ensure all necessary data files are located within this directory.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The rule with id="&lt;RULE_ID&gt;" has not been executed.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The rule with the provided id has not been executed during this validation.</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Ensure that a test data file exists that matches the conditions defined in the specified rule.</p></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="overriding-rules_rules-development-guide-appcat">5. Overriding rules</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>You can override core rules distributed with APPCAT or even custom rules. For example, you can change the matching conditions, effort, or hint text for a rule. This is done by making a copy of the original rule, marking it as a rule override, and making the necessary adjustments.</p>
+            </div>
+            <div class="paragraph">
+                <p>You can disable a rule by creating a rule override with an empty <code>&lt;rule&gt;</code> element.</p>
+            </div>
+            <div class="sect2">
+                <h3 id="_overriding_a_rule">5.1. Overriding a rule</h3>
+                <div class="paragraph">
+                    <p>You can override a core or custom rule.</p>
+                </div>
+                <div class="olist arabic">
+                    <div class="title">Procedure</div>
+                    <ol class="arabic">
+                        <li>
+                            <p>Copy the XML file that contains the rule you want to override to the custom rules directory.</p>
+                            <div class="paragraph">
+                                <p>Custom rules can be placed in <code>&lt;APPCAT_HOME&gt;/rules</code>, <code>${user.home}/.appcat/rules/</code>, or a directory specified by the <code>--userRulesDirectory</code> command-line argument.</p>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Edit the XML file so that it contains only the <code>&lt;rule&gt;</code> elements for the rules that you want to override.</p>
+                            <div class="admonitionblock note">
+                                <table>
+                                    <tr>
+                                        <td class="icon">
+                                            <div class="title">Note</div>
+                                        </td>
+                                        <td class="content">
+                                            <div class="paragraph">
+                                                <p>Rules from the original ruleset that are not overridden by the new ruleset are run as normal.</p>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </div>
+                        </li>
+                        <li>
+                            <p>Ensure that you keep the same rule and ruleset IDs. When you copy the original rule XML, this ensures that the IDs match.</p>
+                        </li>
+                        <li>
+                            <p>Add the <code>&lt;overrideRules&gt;true&lt;/overrideRules&gt;</code> element to the ruleset metadata.</p>
+                        </li>
+                        <li>
+                            <p>Update the rule definition.</p>
+                            <div class="paragraph">
+                                <p>You can change anything in the rule definition. The new rule overrides the original rule in its entirety.</p>
+                            </div>
+                        </li>
+                    </ol>
+                </div>
+                <div class="paragraph">
+                    <p>The following rule override example changes the <code>effort</code> of the <code>weblogic-02000</code> rule in the <code>weblogic</code> ruleset from <code>1</code> to <code>3</code>:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="title">Rule override definition example</div>
+                    <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset id="weblogic"
     xmlns="http://windup.jboss.org/schema/jboss-ruleset"
@@ -3846,36 +3846,36 @@ API Specification" /&gt;</code></pre>
         &lt;/rule&gt;
     &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-<div class="colist arabic">
-<ol>
-<li>
-<p>Ensure that the <code>ruleset id</code> matches the original <code>ruleset id</code>.</p>
-</li>
-<li>
-<p>Add <code>&lt;overrideRules&gt;true&lt;/overrideRules&gt;</code> to the <code>&lt;metadata&gt;</code> section.</p>
-</li>
-<li>
-<p>Ensure that the <code>rule id</code> matches the original <code>rule id</code>.</p>
-</li>
-<li>
-<p>Updated <code>effort</code>.</p>
-</li>
-</ol>
-</div>
-<div class="paragraph">
-<p>When you run APPCAT, this rule overrides the original rule with the same rule ID. You can verify that the new rule was used by viewing the contents of the Rule Provider Executions Overview.</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_disabling_a_rule">5.2. Disabling a rule</h3>
-<div class="paragraph">
-<p>To disable a rule, create a rule override definition with an empty <code>&lt;rule&gt;</code> element according to the following example:</p>
-</div>
-<div class="listingblock">
-<div class="title">Rule override definition example to disable a rule</div>
-<div class="content">
+                    </div>
+                </div>
+                <div class="colist arabic">
+                    <ol>
+                        <li>
+                            <p>Ensure that the <code>ruleset id</code> matches the original <code>ruleset id</code>.</p>
+                        </li>
+                        <li>
+                            <p>Add <code>&lt;overrideRules&gt;true&lt;/overrideRules&gt;</code> to the <code>&lt;metadata&gt;</code> section.</p>
+                        </li>
+                        <li>
+                            <p>Ensure that the <code>rule id</code> matches the original <code>rule id</code>.</p>
+                        </li>
+                        <li>
+                            <p>Updated <code>effort</code>.</p>
+                        </li>
+                    </ol>
+                </div>
+                <div class="paragraph">
+                    <p>When you run APPCAT, this rule overrides the original rule with the same rule ID. You can verify that the new rule was used by viewing the contents of the Rule Provider Executions Overview.</p>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_disabling_a_rule">5.2. Disabling a rule</h3>
+                <div class="paragraph">
+                    <p>To disable a rule, create a rule override definition with an empty <code>&lt;rule&gt;</code> element according to the following example:</p>
+                </div>
+                <div class="listingblock">
+                    <div class="title">Rule override definition example to disable a rule</div>
+                    <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;ruleset id="weblogic"
     xmlns="http://windup.jboss.org/schema/jboss-ruleset"
@@ -3891,66 +3891,66 @@ API Specification" /&gt;</code></pre>
         &lt;/rule&gt;
     &lt;/rules&gt;
 &lt;/ruleset&gt;</code></pre>
-</div>
-</div>
-<div class="colist arabic">
-<ol>
-<li>
-<p>The <code>&lt;rule&gt;</code> element is empty so that the <code>weblogic-02000</code> rule in the <code>weblogic</code> ruleset is disabled.</p>
-</li>
-</ol>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="rule-categories_rules-development-guide-appcat">6. Using custom rule categories</h2>
-<div class="sectionbody">
-<div class="paragraph">
-<p>You can create custom rule categories and assign APPCAT rules to them.</p>
-</div>
-<div class="admonitionblock note">
-<table>
-<tr>
-<td class="icon">
-<div class="title">Note</div>
-</td>
-<td class="content">
-<div class="paragraph">
-<p>Although APPCAT processes rules with the legacy <code>severity</code> field, you must update your custom rules to use the new <code>category-id</code> field.</p>
-</div>
-</td>
-</tr>
-</table>
-</div>
-<h3 id="add_custom_category_rules-development-guide-appcat" class="discrete">Adding a custom category</h3>
-<div class="paragraph">
-<p>You can add a custom category to the rule category file.</p>
-</div>
-<div class="olist arabic">
-<div class="title">Procedure</div>
-<ol class="arabic">
-<li>
-<p>Edit the rule category file, which is located at <code>&lt;APPCAT_HOME&gt;/rules/migration-core/core.windup.categories.xml</code>.</p>
-</li>
-<li>
-<p>Add a new <code>&lt;category&gt;</code> element and fill in the following parameters:</p>
-<div class="ulist">
-<ul>
-<li>
-<p><code>id</code>: The ID that APPCAT rules use to reference the category.</p>
-</li>
-<li>
-<p><code>priority</code>: The sorting priority relative to other categories. The category with the lowest value is displayed first.</p>
-</li>
-<li>
-<p><code>name</code>: The display name of the category.</p>
-</li>
-<li>
-<p><code>description</code>: The description of the category.</p>
-<div class="listingblock">
-<div class="title">Custom rule category example</div>
-<div class="content">
+                    </div>
+                </div>
+                <div class="colist arabic">
+                    <ol>
+                        <li>
+                            <p>The <code>&lt;rule&gt;</code> element is empty so that the <code>weblogic-02000</code> rule in the <code>weblogic</code> ruleset is disabled.</p>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="rule-categories_rules-development-guide-appcat">6. Using custom rule categories</h2>
+        <div class="sectionbody">
+            <div class="paragraph">
+                <p>You can create custom rule categories and assign APPCAT rules to them.</p>
+            </div>
+            <div class="admonitionblock note">
+                <table>
+                    <tr>
+                        <td class="icon">
+                            <div class="title">Note</div>
+                        </td>
+                        <td class="content">
+                            <div class="paragraph">
+                                <p>Although APPCAT processes rules with the legacy <code>severity</code> field, you must update your custom rules to use the new <code>category-id</code> field.</p>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h3 id="add_custom_category_rules-development-guide-appcat" class="discrete">Adding a custom category</h3>
+            <div class="paragraph">
+                <p>You can add a custom category to the rule category file.</p>
+            </div>
+            <div class="olist arabic">
+                <div class="title">Procedure</div>
+                <ol class="arabic">
+                    <li>
+                        <p>Edit the rule category file, which is located at <code>&lt;APPCAT_HOME&gt;/rules/migration-core/core.windup.categories.xml</code>.</p>
+                    </li>
+                    <li>
+                        <p>Add a new <code>&lt;category&gt;</code> element and fill in the following parameters:</p>
+                        <div class="ulist">
+                            <ul>
+                                <li>
+                                    <p><code>id</code>: The ID that APPCAT rules use to reference the category.</p>
+                                </li>
+                                <li>
+                                    <p><code>priority</code>: The sorting priority relative to other categories. The category with the lowest value is displayed first.</p>
+                                </li>
+                                <li>
+                                    <p><code>name</code>: The display name of the category.</p>
+                                </li>
+                                <li>
+                                    <p><code>description</code>: The description of the category.</p>
+                                    <div class="listingblock">
+                                        <div class="title">Custom rule category example</div>
+                                        <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;?xml version="1.0"?&gt;
 &lt;categories&gt;
     ...
@@ -3959,27 +3959,27 @@ API Specification" /&gt;</code></pre>
         &lt;description&gt;This is a custom category.&lt;/description&gt;
     &lt;/category&gt;
 &lt;/categories&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>This category is ready to be referenced by APPCAT rules.</p>
-</div>
-</li>
-</ul>
-</div>
-</li>
-</ol>
-</div>
-<h3 id="assign_custom_category_rules-development-guide-appcat" class="discrete">Assigning a rule to a custom category</h3>
-<div class="paragraph">
-<p>You can assign a rule to your new custom category.</p>
-</div>
-<div class="paragraph">
-<div class="title">Procedure</div>
-<p>In your APPCAT rule, update the <code>category-id</code> field as in the following example.</p>
-</div>
-<div class="listingblock">
-<div class="content">
+                                        </div>
+                                    </div>
+                                    <div class="paragraph">
+                                        <p>This category is ready to be referenced by APPCAT rules.</p>
+                                    </div>
+                                </li>
+                            </ul>
+                        </div>
+                    </li>
+                </ol>
+            </div>
+            <h3 id="assign_custom_category_rules-development-guide-appcat" class="discrete">Assigning a rule to a custom category</h3>
+            <div class="paragraph">
+                <p>You can assign a rule to your new custom category.</p>
+            </div>
+            <div class="paragraph">
+                <div class="title">Procedure</div>
+                <p>In your APPCAT rule, update the <code>category-id</code> field as in the following example.</p>
+            </div>
+            <div class="listingblock">
+                <div class="content">
 <pre class="highlight"><code class="language-xml" data-lang="xml">&lt;rule id="rule-id"&gt;
     &lt;when&gt;
         ...
@@ -3990,213 +3990,213 @@ API Specification" /&gt;</code></pre>
         &lt;/hint&gt;
     &lt;/perform&gt;
  &lt;/rule&gt;</code></pre>
-</div>
-</div>
-<div class="paragraph">
-<p>If this rule condition is met, incidents identified by this rule use your custom category. The custom category is displayed on the dashboard and in the Issues report.</p>
-</div>
-<div class="imageblock">
-<div class="content">
-<img src="topics/images/custom_rule_category-appcat.png" alt="Custom rule category on the Dashboard">
-</div>
-<div class="title">Figure 3. Custom category on the dashboard</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_reference_material">Appendix A: Reference material</h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="about-story-points_rules-development-guide-appcat">A.1. About rule story points</h3>
-<div class="sect3">
-<h4 id="_what_are_story_points">A.1.1. What are story points?</h4>
-<div class="paragraph">
-<p><em>Story points</em> are an abstract metric commonly used in Agile software development to estimate the <em>level of effort</em> needed to implement a feature or change.</p>
-</div>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit uses story points to express the level of effort needed to migrate particular application constructs, and the application as a whole. It does not necessarily translate to man-hours, but the value should be consistent across tasks.</p>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_how_story_points_are_estimated_in_rules">A.1.2. How story points are estimated in rules</h4>
-<div class="paragraph">
-<p>Estimating the level of effort for the story points for a rule can be tricky. The following are the general guidelines APPCAT uses when estimating the level of effort required for a rule.</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 15%;">
-<col style="width: 60%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Level of Effort</th>
-<th class="tableblock halign-left valign-top">Story Points</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Information</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">An informational warning with very low or no priority for migration.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Trivial</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration is a trivial change or a simple library swap with no or minimal API changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Complex</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The changes required for the migration task are complex, but have a documented solution.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Redesign</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration task requires a redesign or a complete library change, with significant API changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rearchitecture</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration requires a complete rearchitecture of the component or subsystem.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unknown</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">13</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The migration solution is not known and may need a complete rewrite.</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_task_category">A.1.3. Task category</h4>
-<div class="paragraph">
-<p>In addition to the level of effort, you can categorize migration tasks to indicate the severity of the task. The following categories are used to group issues to help prioritize the migration effort.</p>
-</div>
-<div class="dlist">
-<dl>
-<dt class="hdlist1">Mandatory</dt>
-<dd>
-<p>The task must be completed for a successful migration. If the changes are not made, the resulting application will not build or run successfully. Examples include replacement of proprietary APIs that are not supported in the target platform.</p>
-</dd>
-<dt class="hdlist1">Optional</dt>
-<dd>
-<p>If the migration task is not completed, the application should work, but the results may not be optimal. If the change is not made at the time of migration, it is recommended to put it on the schedule soon after your migration is completed. An example of this would be the upgrade of EJB 2.x code to EJB 3.</p>
-</dd>
-<dt class="hdlist1">Potential</dt>
-<dd>
-<p>The task should be examined during the migration process, but there is not enough detailed information to determine if the task is mandatory for the migration to succeed. An example of this would be migrating a third-party proprietary type where there is no directly compatible type.</p>
-</dd>
-<dt class="hdlist1">Information</dt>
-<dd>
-<p>The task is included to inform you of the existence of certain files. These may need to be examined or modified as part of the modernization effort, but changes are typically not required. An example of this would be the presence of a logging dependency or a Maven <code>pom.xml</code>.</p>
-</dd>
-</dl>
-</div>
-<div class="paragraph">
-<p>For more information on categorizing tasks, see <a href="#rule-categories_rules-development-guide-appcat">Using custom rule categories</a>.</p>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_additional_resources">A.2. Additional resources</h3>
-<div class="sect3">
-<h4 id="review-existing-rules_rules-development-guide-appcat">A.2.1. Reviewing existing APPCAT XML rules</h4>
-<div class="paragraph">
-<p>APPCAT XML-based rules are located on GitHub at the following location: <a href="https://github.com/Azure/appcat-rulesets/tree/master/rules/rules-reviewed">https://github.com/Azure/appcat-rulesets/tree/master/rules/rules-reviewed</a>.</p>
-</div>
-<div class="paragraph">
-<p>You can fork and clone the APPCAT XML rules on your local machine.</p>
-</div>
-<div class="paragraph">
-<p>Rules are grouped by target platform and function. When you create a new rule, it is helpful to find a rule that is similar to the one you need and use it as a starting template.</p>
-</div>
-<div class="paragraph">
-<p>New rules are continually added, so it is a good idea to check back frequently to review the updates.</p>
-</div>
-<div class="sect4">
-<h5 id="fork-ruleset-repo_rules-development-guide-appcat">Forking and cloning the Azure Application and Code Assessment Toolkit XML rules</h5>
-<div class="paragraph">
-<p>The Azure Application and Code Assessment Toolkit <code>appcat-rulesets</code> repository provide working examples of how to create custom Java-based rule add-ons and XML rules. You can use them as a starting point for creating your own custom rules.</p>
-</div>
-<div class="paragraph">
-<p>You must have the <a href="http://git-scm.com/"><code>git</code></a> client installed on your machine.</p>
-</div>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p>Click the <code>Fork</code> link on the <a href="https://github.com/Azure/appcat-rulesets">Azure Application and Code Assessment Toolkit Rulesets</a> GitHub page to create the project in your own Git. The forked GitHub repository URL created by the fork should look like this: <code>https://github.com/&lt;YOUR_USER_NAME&gt;/appcat-rulesets.git</code>.</p>
-</li>
-<li>
-<p>Clone your Azure Application and Code Assessment Toolkit rulesets repository to your local file system:</p>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ git clone https://github.com/&lt;YOUR_USER_NAME&gt;/appcat-rulesets.git</pre>
-</div>
-</div>
-</li>
-<li>
-<p>This creates and populates a <code>appcat-rulesets</code> directory on your local file system. Navigate to the newly created directory, for example</p>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ cd appcat-rulesets/</pre>
-</div>
-</div>
-</li>
-<li>
-<p>If you want to be able to retrieve the latest code updates, add the remote <code>upstream</code> repository so you can fetch any changes to the original forked repository.</p>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ git remote add upstream https://github.com/Azure/appcat-rulesets.git</pre>
-</div>
-</div>
-</li>
-<li>
-<p>Get the latest files from the <code>upstream</code> repository.</p>
-<div class="listingblock">
-<div class="content">
-<pre class="nowrap">$ git fetch upstream</pre>
-</div>
-</div>
-</li>
-</ol>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="rules-important-links_rules-development-guide-appcat">A.2.2. Additional resources</h4>
-<div class="ulist">
-<ul>
-<li>
-<p>APPCAT Javadoc: <a href="http://windup.github.io/windup/docs/latest/javadoc" class="bare">http://windup.github.io/windup/docs/latest/javadoc</a></p>
-</li>
-<li>
-<p>APPCAT Jira issue tracker: <a href="https://github.com/Azure/appcat-rulesets/issues" class="bare">https://github.com/Azure/appcat-rulesets/issues</a></p>
-</li>
-<li>
-<p>APPCAT mailing list: <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a></p>
-</li>
-</ul>
-</div>
-<div class="paragraph">
-<p><br>
-<br>
-<br>
-<br></p>
-</div>
-<div class="paragraph">
-<p><em class="right">Revised on 2023-08-08 02:32:15 UTC</em></p>
-</div>
-</div>
-</div>
-</div>
-</div>
+                </div>
+            </div>
+            <div class="paragraph">
+                <p>If this rule condition is met, incidents identified by this rule use your custom category. The custom category is displayed on the dashboard and in the Issues report.</p>
+            </div>
+            <div class="imageblock">
+                <div class="content">
+                    <img src="topics/images/custom_rule_category-appcat.png" alt="Custom rule category on the Dashboard">
+                </div>
+                <div class="title">Figure 3. Custom category on the dashboard</div>
+            </div>
+        </div>
+    </div>
+    <div class="sect1">
+        <h2 id="_reference_material">Appendix A: Reference material</h2>
+        <div class="sectionbody">
+            <div class="sect2">
+                <h3 id="about-story-points_rules-development-guide-appcat">A.1. About rule story points</h3>
+                <div class="sect3">
+                    <h4 id="_what_are_story_points">A.1.1. What are story points?</h4>
+                    <div class="paragraph">
+                        <p><em>Story points</em> are an abstract metric commonly used in Agile software development to estimate the <em>level of effort</em> needed to implement a feature or change.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>The Azure Migrate application and code assessment for Java uses story points to express the level of effort needed to migrate particular application constructs, and the application as a whole. It does not necessarily translate to man-hours, but the value should be consistent across tasks.</p>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="_how_story_points_are_estimated_in_rules">A.1.2. How story points are estimated in rules</h4>
+                    <div class="paragraph">
+                        <p>Estimating the level of effort for the story points for a rule can be tricky. The following are the general guidelines APPCAT uses when estimating the level of effort required for a rule.</p>
+                    </div>
+                    <table class="tableblock frame-all grid-all stretch">
+                        <colgroup>
+                            <col style="width: 25%;">
+                            <col style="width: 15%;">
+                            <col style="width: 60%;">
+                        </colgroup>
+                        <thead>
+                        <tr>
+                            <th class="tableblock halign-left valign-top">Level of Effort</th>
+                            <th class="tableblock halign-left valign-top">Story Points</th>
+                            <th class="tableblock halign-left valign-top">Description</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Information</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">An informational warning with very low or no priority for migration.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Trivial</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration is a trivial change or a simple library swap with no or minimal API changes.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Complex</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The changes required for the migration task are complex, but have a documented solution.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Redesign</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration task requires a redesign or a complete library change, with significant API changes.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Rearchitecture</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration requires a complete rearchitecture of the component or subsystem.</p></td>
+                        </tr>
+                        <tr>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">Unknown</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">13</p></td>
+                            <td class="tableblock halign-left valign-top"><p class="tableblock">The migration solution is not known and may need a complete rewrite.</p></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="sect3">
+                    <h4 id="_task_category">A.1.3. Task category</h4>
+                    <div class="paragraph">
+                        <p>In addition to the level of effort, you can categorize migration tasks to indicate the severity of the task. The following categories are used to group issues to help prioritize the migration effort.</p>
+                    </div>
+                    <div class="dlist">
+                        <dl>
+                            <dt class="hdlist1">Mandatory</dt>
+                            <dd>
+                                <p>The task must be completed for a successful migration. If the changes are not made, the resulting application will not build or run successfully. Examples include replacement of proprietary APIs that are not supported in the target platform.</p>
+                            </dd>
+                            <dt class="hdlist1">Optional</dt>
+                            <dd>
+                                <p>If the migration task is not completed, the application should work, but the results may not be optimal. If the change is not made at the time of migration, it is recommended to put it on the schedule soon after your migration is completed. An example of this would be the upgrade of EJB 2.x code to EJB 3.</p>
+                            </dd>
+                            <dt class="hdlist1">Potential</dt>
+                            <dd>
+                                <p>The task should be examined during the migration process, but there is not enough detailed information to determine if the task is mandatory for the migration to succeed. An example of this would be migrating a third-party proprietary type where there is no directly compatible type.</p>
+                            </dd>
+                            <dt class="hdlist1">Information</dt>
+                            <dd>
+                                <p>The task is included to inform you of the existence of certain files. These may need to be examined or modified as part of the modernization effort, but changes are typically not required. An example of this would be the presence of a logging dependency or a Maven <code>pom.xml</code>.</p>
+                            </dd>
+                        </dl>
+                    </div>
+                    <div class="paragraph">
+                        <p>For more information on categorizing tasks, see <a href="#rule-categories_rules-development-guide-appcat">Using custom rule categories</a>.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="sect2">
+                <h3 id="_additional_resources">A.2. Additional resources</h3>
+                <div class="sect3">
+                    <h4 id="review-existing-rules_rules-development-guide-appcat">A.2.1. Reviewing existing APPCAT XML rules</h4>
+                    <div class="paragraph">
+                        <p>APPCAT XML-based rules are located on GitHub at the following location: <a href="https://github.com/Azure/appcat-rulesets/tree/master/rules/rules-reviewed">https://github.com/Azure/appcat-rulesets/tree/master/rules/rules-reviewed</a>.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>You can fork and clone the APPCAT XML rules on your local machine.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>Rules are grouped by target platform and function. When you create a new rule, it is helpful to find a rule that is similar to the one you need and use it as a starting template.</p>
+                    </div>
+                    <div class="paragraph">
+                        <p>New rules are continually added, so it is a good idea to check back frequently to review the updates.</p>
+                    </div>
+                    <div class="sect4">
+                        <h5 id="fork-ruleset-repo_rules-development-guide-appcat">Forking and cloning the Azure Migrate application and code assessment for Java XML rules</h5>
+                        <div class="paragraph">
+                            <p>The Azure Migrate application and code assessment for Java <code>appcat-rulesets</code> repository provide working examples of how to create custom Java-based rule add-ons and XML rules. You can use them as a starting point for creating your own custom rules.</p>
+                        </div>
+                        <div class="paragraph">
+                            <p>You must have the <a href="http://git-scm.com/"><code>git</code></a> client installed on your machine.</p>
+                        </div>
+                        <div class="olist arabic">
+                            <ol class="arabic">
+                                <li>
+                                    <p>Click the <code>Fork</code> link on the <a href="https://github.com/Azure/appcat-rulesets">Azure Migrate application and code assessment for Java Rulesets</a> GitHub page to create the project in your own Git. The forked GitHub repository URL created by the fork should look like this: <code>https://github.com/&lt;YOUR_USER_NAME&gt;/appcat-rulesets.git</code>.</p>
+                                </li>
+                                <li>
+                                    <p>Clone your Azure Migrate application and code assessment for Java rulesets repository to your local file system:</p>
+                                    <div class="listingblock">
+                                        <div class="content">
+                                            <pre class="nowrap">$ git clone https://github.com/&lt;YOUR_USER_NAME&gt;/appcat-rulesets.git</pre>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <p>This creates and populates a <code>appcat-rulesets</code> directory on your local file system. Navigate to the newly created directory, for example</p>
+                                    <div class="listingblock">
+                                        <div class="content">
+                                            <pre class="nowrap">$ cd appcat-rulesets/</pre>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <p>If you want to be able to retrieve the latest code updates, add the remote <code>upstream</code> repository so you can fetch any changes to the original forked repository.</p>
+                                    <div class="listingblock">
+                                        <div class="content">
+                                            <pre class="nowrap">$ git remote add upstream https://github.com/Azure/appcat-rulesets.git</pre>
+                                        </div>
+                                    </div>
+                                </li>
+                                <li>
+                                    <p>Get the latest files from the <code>upstream</code> repository.</p>
+                                    <div class="listingblock">
+                                        <div class="content">
+                                            <pre class="nowrap">$ git fetch upstream</pre>
+                                        </div>
+                                    </div>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+                <div class="sect3">
+                    <h4 id="rules-important-links_rules-development-guide-appcat">A.2.2. Additional resources</h4>
+                    <div class="ulist">
+                        <ul>
+                            <li>
+                                <p>APPCAT Javadoc: <a href="http://windup.github.io/windup/docs/latest/javadoc" class="bare">http://windup.github.io/windup/docs/latest/javadoc</a></p>
+                            </li>
+                            <li>
+                                <p>APPCAT Jira issue tracker: <a href="https://github.com/Azure/appcat-rulesets/issues" class="bare">https://github.com/Azure/appcat-rulesets/issues</a></p>
+                            </li>
+                            <li>
+                                <p>APPCAT mailing list: <a href="mailto:azure-appcat@microsoft.com">azure-appcat@microsoft.com</a></p>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="paragraph">
+                        <p><br>
+                            <br>
+                            <br>
+                            <br></p>
+                    </div>
+                    <div class="paragraph">
+                        <p><em class="right">Revised on 2023-11-14 15:17:32 UTC</em></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 <div id="footer">
-<div id="footer-text">
-Last updated 2023-08-08 02:32:13 UTC
-</div>
+    <div id="footer-text">
+        Last updated 2023-11-14 15:17:26 UTC
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
This PR contains the below updates to the documentation: 

- Product name changes to "Azure Migrate application and code assessment for Java"
- Binary executable name changes to "appcat" from "appcat-cli"
- Refactoring: Added formatting to the html docs